### PR TITLE
Directly use base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM ghcr.io/laminas/laminas-continuous-integration-container:1
-
-LABEL "repository"="http://github.com/laminas/laminas-continuous-integration-action"
-LABEL "homepage"="http://github.com/laminas/laminas-continuous-integration-action"
-LABEL "maintainer"="https://github.com/laminas/technical-steering-committee/"
-
-LABEL "com.github.actions.icon"="check"
-LABEL "com.github.actions.color"="green"

--- a/README.md
+++ b/README.md
@@ -55,3 +55,8 @@ jobs:
         with:
           job: ${{ matrix.job }}
 ```
+
+> ### DO NOT use actions/checkout
+>
+> **DO NOT** use the `actions/checkout` action in a step prior to using this action.
+> Doing so will lead to errors, as this action performs git checkouts into the WORKDIR, and a non-empty WORKDIR causes that operation to fail.

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,6 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/laminas/laminas-continuous-integration-container:1'
   args:
     - ${{ inputs.job }}


### PR DESCRIPTION
In my original experiments, it appeared we could not directly use docker images; I suspect this was due to also using actions/checkout in prior steps, however.

I've experimented again, and discovered we can directly use the container images, and this can reduce the amount of time "building" the container for the action, as it becomes just a pull operation.