### PR TITLE
Pass though environment variables

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -193,7 +193,7 @@ fi
 set +e
 
 echo "Running ${COMMAND}"
-sudo -u testuser /bin/bash -c "${COMMAND}"
+sudo --preserve-env -u testuser /bin/bash -c "${COMMAND}"
 STATUS=$?
 
 set -e


### PR DESCRIPTION
Adding this flag to sudo will pass existing environment variables to the executed CI command for example `phpunit`
