### PR TITLE
Use non-privileged user home when executing QA command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -193,7 +193,7 @@ fi
 set +e
 
 echo "Running ${COMMAND}"
-sudo --preserve-env -u testuser /bin/bash -c "${COMMAND}"
+sudo --preserve-env --set-home -u testuser /bin/bash -c "${COMMAND}"
 STATUS=$?
 
 set -e


### PR DESCRIPTION
Adds the `--set-home` flag to the `sudo` invocation that calls the actual QA command, ensuring that anything that resolves to `$HOME` resolves to the non-privileged user's home directory.

Fixes #9
