### PR TITLE
Ensure build and push container workflow will work correctly

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -41,4 +41,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ join(fromJSON(steps.tags.outputs.tags), ",") }}
+          tags: ${{ join(fromJSON(steps.tags.outputs.tags), ',') }}


### PR DESCRIPTION
As discovered in laminas/automatic-releases, workflow expressions must use single quotes, not double quotes, for string values.
