### PR TITLE
Ensure newlines are propagated to php.ini settings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,7 +125,7 @@ if [[ "${COMMAND}" == "" ]];then
 fi
 
 EXTENSIONS=$(echo "${JOB}" | jq -r ".extensions | map(\"php${PHP}-\"+.) | join(\" \")")
-INI=$(echo "${JOB}" | jq -r '.ini | join("\n")')
+INI=$(echo "${JOB}" | jq -r '.ini | join("{NL}")')
 DEPS=$(echo "${JOB}" | jq -r '.dependencies')
 
 if [[ "${EXTENSIONS}" != "" ]];then
@@ -151,7 +151,7 @@ fi
 
 if [[ "${INI}" != "" ]];then
     echo "Installing php.ini settings"
-    echo $INI > /etc/php/${PHP}/cli/conf.d/99-settings.ini
+    echo $INI | sed "s/{NL}/\n/g" > /etc/php/${PHP}/cli/conf.d/99-settings.ini
 fi
 
 echo "Marking PHP ${PHP} as configured default"


### PR DESCRIPTION
Bash does not like to capture newlines into variables.  As such, this patch concatenates php.ini settings using the string `{NL}`, which is then translated to a newline when pushing to the php.ini settings file.

Fixes #7
