### PR TITLE
Optimize newline handling for php.ini files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,7 +125,7 @@ if [[ "${COMMAND}" == "" ]];then
 fi
 
 EXTENSIONS=$(echo "${JOB}" | jq -r ".extensions | map(\"php${PHP}-\"+.) | join(\" \")")
-INI=$(echo "${JOB}" | jq -r '.ini | join("{NL}")')
+INI=$(echo "${JOB}" | jq -r '.ini | join("\n")')
 DEPS=$(echo "${JOB}" | jq -r '.dependencies')
 
 if [[ "${EXTENSIONS}" != "" ]];then
@@ -151,7 +151,7 @@ fi
 
 if [[ "${INI}" != "" ]];then
     echo "Installing php.ini settings"
-    echo $INI | sed "s/{NL}/\n/g" > /etc/php/${PHP}/cli/conf.d/99-settings.ini
+    echo "$INI" > /etc/php/${PHP}/cli/conf.d/99-settings.ini
 fi
 
 echo "Marking PHP ${PHP} as configured default"


### PR DESCRIPTION
This reverts b46074cb396c8bf3c7000e9867ca974dbe72d7d5
from https://github.com/laminas/laminas-continuous-integration-action/pull/13/files
