### PR TITLE
feat: add `pre-install` script execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,21 @@ jobs:
 Some packages may require additional setup steps: setting up a web server to test an HTTP client, seeding a database or cache service, etc.
 Other times, you may want to do additional reporting, particularly if the QA command failed.
 
-To enable this, you may create one or both of the following files in your package:
+To enable this, you may create one or more of the following files in your package:
 
-- `.laminas-ci/pre-run.sh`
+- `.laminas-ci/pre-install.sh`
+- `.laminas-ci/pre-run.sh` 
 - `.laminas-ci/post-run.sh`
 
 (Note: the files MUST be executable to be consumed!)
 
-These run immediately before and after the QA command, respectively.
-The `.laminas-ci/pre-run.sh` command will receive the following arguments:
+The `.laminas-ci/pre-install.sh` command runs before any other command is executed in the action, and will receive the following arguments:
+
+- `$1`: the user the QA command will run under
+- `$2`: the WORKDIR path
+- `$3`: the `$JOB` passed to the entrypoint (see above)
+
+The `.laminas-ci/pre-run.sh` command runs immediately prior to the QA command, and will receive the following arguments:
 
 - `$1`: the user the QA command will run under
 - `$2`: the WORKDIR path

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,6 +124,15 @@ if [[ "${COMMAND}" == "" ]];then
     exit 1
 fi
 
+echo "Marking PHP ${PHP} as configured default"
+update-alternatives --set php /usr/bin/php${PHP}
+
+# Is there a pre-install script available?
+if [ -x ".laminas-ci/pre-install.sh" ];then
+    echo "Executing pre-install commands from .laminas-ci/pre-install.sh"
+    ./.laminas-ci/pre-install.sh testuser "${PWD}" "${JOB}"
+fi
+
 EXTENSIONS=$(echo "${JOB}" | jq -r ".extensions | map(\"php${PHP}-\"+.) | join(\" \")")
 INI=$(echo "${JOB}" | jq -r '.ini | join("{NL}")')
 DEPS=$(echo "${JOB}" | jq -r '.dependencies')
@@ -153,9 +162,6 @@ if [[ "${INI}" != "" ]];then
     echo "Installing php.ini settings"
     echo $INI | sed "s/{NL}/\n/g" > /etc/php/${PHP}/cli/conf.d/99-settings.ini
 fi
-
-echo "Marking PHP ${PHP} as configured default"
-update-alternatives --set php /usr/bin/php${PHP}
 
 echo "PHP version: $(php --version)"
 echo "Installed extensions:"


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

In `laminas-cache`, we have use-cases where we either want to manually compile PHP extensions with `pecl` to suit composer requirements or extending the ENV for `composer` to avoid circular dependency issues.

The current `pre-run.sh` is being executed **after** `composer install` is being executed and thus, it will fail before we reach the script.
In order to solve that issue, I'd like to introduce a `pre-install.sh` script, which is being executed in an earlier stage of the process.
