### PR TITLE
PECL for multiple PHP versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ RUN apt update \
         yamllint \
         zip \
         msodbcsql17 \
-        php5.6-cli \
         php5.6-bz2 \
+        php5.6-cli \
         php5.6-curl \
+        php5.6-dev \
         php5.6-fileinfo \
         php5.6-intl \
         php5.6-json \
@@ -39,6 +40,7 @@ RUN apt update \
         php7.0-cli \
         php7.0-bz2 \
         php7.0-curl \
+        php7.0-dev \
         php7.0-fileinfo \
         php7.0-intl \
         php7.0-json \
@@ -52,6 +54,7 @@ RUN apt update \
         php7.1-cli \
         php7.1-bz2 \
         php7.1-curl \
+        php7.1-dev \
         php7.1-fileinfo \
         php7.1-intl \
         php7.1-json \
@@ -65,6 +68,7 @@ RUN apt update \
         php7.2-cli \
         php7.2-bz2 \
         php7.2-curl \
+        php7.2-dev \
         php7.2-fileinfo \
         php7.2-intl \
         php7.2-json \
@@ -78,6 +82,7 @@ RUN apt update \
         php7.3-cli \
         php7.3-bz2 \
         php7.3-curl \
+        php7.3-dev \
         php7.3-fileinfo \
         php7.3-intl \
         php7.3-json \
@@ -91,6 +96,7 @@ RUN apt update \
         php7.4-cli \
         php7.4-bz2 \
         php7.4-curl \
+        php7.4-dev \
         php7.4-fileinfo \
         php7.4-intl \
         php7.4-json \
@@ -104,6 +110,7 @@ RUN apt update \
         php8.0-cli \
         php8.0-bz2 \
         php8.0-curl \
+        php8.0-dev \
         php8.0-fileinfo \
         php8.0-intl \
         php8.0-mbstring \

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Other times, you may want to do additional reporting, particularly if the QA com
 To enable this, you may create one or more of the following files in your package:
 
 - `.laminas-ci/pre-install.sh`
-- `.laminas-ci/pre-run.sh` 
+- `.laminas-ci/pre-run.sh`
 - `.laminas-ci/post-run.sh`
 
 (Note: the files MUST be executable to be consumed!)
@@ -125,6 +125,20 @@ fi
 ```
 
 If you need access to the list of extensions or php.ini directives, you should likely write a script in PHP or node to do so.
+
+#### Using PECL
+
+One key reason to use a `.laminas-ci/pre-install.sh` script is to install an extension via PECL.
+You may need to do this if no corresponding package exists for an extension you need, or if you need to test against a different version than is in the Sury repository.
+
+An example of such a script:
+
+```bash
+#!/bin/bsh
+# .laminas-ci/pre-install.sh
+
+pecl install couchbase-2.6.2
+```
 
 ### Using locally
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,7 +125,9 @@ if [[ "${COMMAND}" == "" ]];then
 fi
 
 echo "Marking PHP ${PHP} as configured default"
-update-alternatives --set php /usr/bin/php${PHP}
+update-alternatives --quiet --set php /usr/bin/php${PHP}
+update-alternatives --quiet --set php-config /usr/bin/php-config${PHP}
+update-alternatives --quiet --set phpize /usr/bin/phpize${PHP}
 
 # Is there a pre-install script available?
 if [ -x ".laminas-ci/pre-install.sh" ];then


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| New Feature   | yes/no

### Description

With #19 we add `pre-install` script support which can use `pecl` to install extensions which are not pre-compiled with this action.

I've used Ondřej example from [here](https://github.com/oerdnj/deb.sury.org/wiki/PECL-Installation) to set alternatives for `php-config` and `phpize`.
To do so, the docker container has to provide `php-dev` for all PHP versions aswell.