### PR TITLE
bugfix: checkout the source before interacting with it

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,6 +129,8 @@ update-alternatives --quiet --set php /usr/bin/php${PHP}
 update-alternatives --quiet --set php-config /usr/bin/php-config${PHP}
 update-alternatives --quiet --set phpize /usr/bin/phpize${PHP}
 
+checkout
+
 # Is there a pre-install script available?
 if [ -x ".laminas-ci/pre-install.sh" ];then
     echo "Executing pre-install commands from .laminas-ci/pre-install.sh"
@@ -168,8 +170,6 @@ fi
 echo "PHP version: $(php --version)"
 echo "Installed extensions:"
 php -m
-
-checkout
 
 composer_install "${DEPS}" "${PHP}"
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With https://github.com/laminas/laminas-continuous-integration-action/pull/19, the `.laminas-ci/pre-install.sh` script was introduced.
I totally missed, that the checkout of the repository takes place later in the process.

This fix moves the `checkout` right after the PHP version handling and right before the check for the `pre-install.sh` script.
