### PR TITLE
feat: use empty command for nothing to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The JSON string should represent an object with the following information:
     "php.ini directives, one per element; e.g. 'memory_limit=-1'",
   ],
   "dependencies": "dependencies to test against; one of lowest, locked, latest",
-  "command": "command to run to perform the check",
+  "command": "command to run to perform the check (empty in case you dont want to excecute any command)"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The JSON string should represent an object with the following information:
 {
   "php": "string PHP minor version to run against",
   "extensions": [
-    "extension names to install; names are from the ondrej PHP repository, minus the php{VERSION}- prefix",
+    "extension names to install; names are from the ondrej PHP repository, minus the php{VERSION}- prefix"
   ],
   "ini": [
-    "php.ini directives, one per element; e.g. 'memory_limit=-1'",
+    "php.ini directives, one per element; e.g. 'memory_limit=-1'"
   ],
   "dependencies": "dependencies to test against; one of lowest, locked, latest",
   "command": "command to run to perform the check (empty in case you dont want to excecute any command)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,10 +111,10 @@ JOB=$1
 echo "Received job: ${JOB}"
 
 COMMAND=$(echo "${JOB}" | jq -r '.command')
-if [[ "${COMMAND}" == "" ]];then
-    echo "Missing command in job; nothing to run"
-    help
-    exit 1
+
+if [[ "${$COMMAND}" == ""];then
+    echo "Command is empty; nothing to run"
+    exit 0
 fi
 
 PHP=$(echo "${JOB}" | jq -r '.php')


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Currently, the matrix generation creates the command `echo 'No checks discovered'`.
Somehow, the `.laminas-ci.json` content is not merged and thus, the check fails when an extension is required to run.

Imho, there should be some kind of "early success" when there is nothing to check. Thus, neither a `checkout` nor `composer install` should be performed.

With this PR, I'd like to introduce that empty strings for the `command` will result in a "nothing to do" secnario and thus exiting with a successful exit code .