### PR TITLE
fix: fix some typos in entrypoint shell script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -112,13 +112,13 @@ echo "Received job: ${JOB}"
 
 COMMAND=$(echo "${JOB}" | jq -r '.command')
 
-if [[ "${$COMMAND}" == ""];then
+if [[ "${COMMAND}" == "" ]];then
     echo "Command is empty; nothing to run"
     exit 0
 fi
 
 PHP=$(echo "${JOB}" | jq -r '.php')
-if [[ "${COMMAND}" == "" ]];then
+if [[ "${PHP}" == "" || "${PHP}" == "null" ]];then
     echo "Missing PHP version in job"
     help
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,7 +118,7 @@ if [[ "${COMMAND}" == "" ]];then
 fi
 
 PHP=$(echo "${JOB}" | jq -r '.php')
-if [[ "${PHP}" == "" || "${PHP}" == "null" ]];then
+if [[ "${PHP}" == "" ]];then
     echo "Missing PHP version in job"
     help
     exit 1


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes a syntax error in an `if` condition.

Also, usage of a wrong variable was fixed and a check for a missing PHP version was added, in addition to the current check for an empty PHP version.
