### PR TITLE
Provide defaults for missing JOB values

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,14 +110,14 @@ fi
 JOB=$1
 echo "Received job: ${JOB}"
 
-COMMAND=$(echo "${JOB}" | jq -r '.command')
+COMMAND=$(echo "${JOB}" | jq -r '.command // ""')
 
 if [[ "${COMMAND}" == "" ]];then
     echo "Command is empty; nothing to run"
     exit 0
 fi
 
-PHP=$(echo "${JOB}" | jq -r '.php')
+PHP=$(echo "${JOB}" | jq -r '.php // ""')
 if [[ "${PHP}" == "" ]];then
     echo "Missing PHP version in job"
     help
@@ -137,9 +137,9 @@ if [ -x ".laminas-ci/pre-install.sh" ];then
     ./.laminas-ci/pre-install.sh testuser "${PWD}" "${JOB}"
 fi
 
-EXTENSIONS=$(echo "${JOB}" | jq -r ".extensions | map(\"php${PHP}-\"+.) | join(\" \")")
-INI=$(echo "${JOB}" | jq -r '.ini | join("\n")')
-DEPS=$(echo "${JOB}" | jq -r '.dependencies')
+EXTENSIONS=$(echo "${JOB}" | jq -r ".extensions // [] | map(\"php${PHP}-\"+.) | join(\" \")")
+INI=$(echo "${JOB}" | jq -r '.ini // [] | join("\n")')
+DEPS=$(echo "${JOB}" | jq -r '.dependencies // "locked"')
 
 if [[ "${EXTENSIONS}" != "" ]];then
 	ENABLE_SQLSRV=false


### PR DESCRIPTION
As reported in Slack, if a value is missing, `jq` returns `null`.  When run normally (e.g., `echo "${JOB}" | jq -r '.somekey'`), this becomes an empty string when the key is missing. However, when run within a subshell (e.g., when assigning to a variable, such as `VALUE=$(echo "${JOB}" | jq -r '.somekey')`), the string `null` is returned.

Fortunately, `jq` allows specifying an alternative value if a value is missing or `false` or `null`, via the `//` operator. This patch adds alternatives everywhere `jq` is invoked when assigning a variable.
