### PR TITLE
Ensure pull request branch name does not cause collisions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,10 +18,13 @@ function help {
 function checkout {
     local REF=
     local LOCAL_BRANCH=
+    local LOCAL_BRANCH_NAME=
 
     if [[ ! $GITHUB_EVENT_NAME || ! $GITHUB_REPOSITORY || ! $GITHUB_REF ]];then
         return
     fi
+
+    LOCAL_BRANCH_NAME=$GITHUB_HEAD_REF
 
     case $GITHUB_EVENT_NAME in
         pull_request)
@@ -33,6 +36,8 @@ function checkout {
                 echo "Missing head or base ref env variables; aborting"
                 exit 1
             fi
+
+            LOCAL_BRANCH_NAME=pull/${LOCAL_BRANCH_NAME}
             ;;
         push)
             REF=${GITHUB_REF/refs\/heads\//}
@@ -66,9 +71,9 @@ function checkout {
         echo "Checking out branch ${BASE_BRANCH}"
         git checkout ${BASE_BRANCH}
         echo "Fetching ref ${REF}"
-        git fetch origin $REF:${GITHUB_HEAD_REF}
-        echo "Checking out to ${GITHUB_HEAD_REF}"
-        git checkout $GITHUB_HEAD_REF
+        git fetch origin "${REF}":"${LOCAL_BRANCH_NAME}"
+        echo "Checking out target ref to ${LOCAL_BRANCH_NAME}"
+        git checkout "${LOCAL_BRANCH_NAME}"
     fi
 }
 


### PR DESCRIPTION
Similar to the issue reported in laminas/laminas-ci-matrix-action#29, we need to ensure that when we fetch the `$GITHUB_REF`, we fetch it into a branch that is named differently than the base branch to avoid collisions and errors.

This patch accomplishes it by adding a `pull/` prefix to the pull request branch name.
