### PR TITLE
Updates configuration for markdownlint to disable MD031 rule for list items

### DIFF
--- a/etc/markdownlint.json
+++ b/etc/markdownlint.json
@@ -4,5 +4,6 @@
     "MD014": false,
     "MD024": false,
     "MD028": false,
+    "MD031": { "list_items": false },
     "MD034": false
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

Blank lines cannot be used for code blocks in lists, otherwise the lists will be discontinued.

Examples:

* https://docs.laminas.dev/laminas-inputfilter/optional-input-filters/
* https://docs.mezzio.dev/mezzio/v3/getting-started/quick-start/#creating-request-handlers

Reference:

> ### MD031 - Fenced code blocks should be surrounded by blank lines
> Set the `list_items` parameter to `false` to disable this rule for list items. Disabling this behavior for lists can be useful if it is necessary to create a tight list containing a code fence.

https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines