### PR TITLE
Add Swoole extension to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,14 @@ COPY mods-available/sqlsrv.ini /etc/php/7.3/mods-available/sqlsrv.ini
 COPY mods-available/sqlsrv.ini /etc/php/7.4/mods-available/sqlsrv.ini
 COPY mods-available/sqlsrv.ini /etc/php/8.0/mods-available/sqlsrv.ini
 
+# Install swoole modules for PHP 7.3 - 8.0
+# (we don't need to support earlier than that in mezzio-swoole)
+COPY mods-available/swoole.ini /etc/php/7.3/mods-available/swoole.ini
+COPY mods-available/swoole.ini /etc/php/7.4/mods-available/swoole.ini
+COPY mods-available/swoole.ini /etc/php/8.0/mods-available/swoole.ini
+COPY scripts/install_swoole.sh /tmp/install_swoole.sh
+RUN /tmp/install_swoole.sh && rm /tmp/install_swoole.sh
+
 RUN mkdir -p /etc/laminas-ci/problem-matcher \
     && cd /etc/laminas-ci/problem-matcher \
     && wget https://raw.githubusercontent.com/shivammathur/setup-php/master/src/configs/phpunit.json \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -159,6 +159,16 @@ if [[ "${EXTENSIONS}" != "" ]];then
 		EXTENSIONS=$(echo ${EXTENSIONS} | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
 	fi
 
+	ENABLE_SWOOLE=false
+	if [[ "${EXTENSIONS}" =~ swoole ]];then
+		if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
+			echo "Skipping enabling of swoole extension; not supported on PHP < 7.3"
+		else
+			ENABLE_SWOOLE=true
+		fi
+		EXTENSIONS=$(echo ${EXTENSIONS} | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
+	fi
+
     echo "Installing extensions: ${EXTENSIONS}"
     apt update
     apt install -y ${EXTENSIONS}
@@ -166,6 +176,11 @@ if [[ "${EXTENSIONS}" != "" ]];then
 	if [[ "${ENABLE_SQLSRV}" == "true" ]];then
 		echo "Enabling sqlsrv extensions"
 		phpenmod -v ${PHP} -s ALL sqlsrv
+	fi
+
+	if [[ "${ENABLE_SWOOLE}" == "true" ]];then
+		echo "Enabling swoole extensions"
+		phpenmod -v ${PHP} -s ALL swoole
 	fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -156,7 +156,7 @@ if [[ "${EXTENSIONS}" != "" ]];then
 		else
 			ENABLE_SQLSRV=true
 		fi
-		EXTENSIONS=$(echo ${EXTENSIONS} | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
+		EXTENSIONS=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
 	fi
 
 	ENABLE_SWOOLE=false
@@ -166,21 +166,21 @@ if [[ "${EXTENSIONS}" != "" ]];then
 		else
 			ENABLE_SWOOLE=true
 		fi
-		EXTENSIONS=$(echo ${EXTENSIONS} | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
+		EXTENSIONS=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
 	fi
 
     echo "Installing extensions: ${EXTENSIONS}"
     apt update
-    apt install -y ${EXTENSIONS}
+    apt install -y "${EXTENSIONS}"
 
 	if [[ "${ENABLE_SQLSRV}" == "true" ]];then
 		echo "Enabling sqlsrv extensions"
-		phpenmod -v ${PHP} -s ALL sqlsrv
+		phpenmod -v "${PHP}" -s ALL sqlsrv
 	fi
 
 	if [[ "${ENABLE_SWOOLE}" == "true" ]];then
 		echo "Enabling swoole extensions"
-		phpenmod -v ${PHP} -s ALL swoole
+		phpenmod -v "${PHP}" -s ALL swoole
 	fi
 fi
 

--- a/mods-available/swoole.ini
+++ b/mods-available/swoole.ini
@@ -1,0 +1,3 @@
+; configuration for php swoole module
+; priority=20
+extension=swoole.so

--- a/scripts/install_swoole.sh
+++ b/scripts/install_swoole.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+SWOOLE_VERSION=4.6.7
+
+# Get swoole package ONCE
+cd /tmp
+wget https://pecl.php.net/get/swoole-${SWOOLE_VERSION}.tgz
+tar xzf swoole-${SWOOLE_VERSION}.tgz
+
+# We only need to support currently supported PHP versions
+for PHP_VERSION in 7.3 7.4 8.0;do
+    cd /tmp/swoole-${SWOOLE_VERSION}
+    if [ -f Makefile ];then
+        make clean
+    fi
+    phpize${PHP_VERSION}
+    ./configure --enable-swoole --enable-sockets --with-php-config=php-config${PHP_VERSION}
+    make
+    make install
+done
+
+# Cleanup
+rm -rf /tmp/swoole-${SWOOLE_VERSION}
+rm /tmp/swoole-${SWOOLE_VERSION}.tgz


### PR DESCRIPTION
This patch compiles and installs the Swoole extension (at version 4.6.7) for PHP versions 7.3, 7.4, and 8.0.  It is NOT enabled by default; enablement is done selectively, as it is done with sqlsrv (combination of a mods-available INI file, and conditional logic when enabling extensions in the entrypoint).  I have built the container locally, and it builds correctly; more importantly, I then ran it against the mezzio-swoole library to ensure I could run unit tests with it, and tests passed.

At some point, we will likely want to:

- Add a script per extension we want to install manually
- Add a script for each of the various functions/conditionals in the entrypoint to make it more modular

For now, however, this works, and will allow us to move forward with adding GHA to mezzio-swoole.
