### PR TITLE
Make extension installation and enablement modular

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,9 +129,7 @@ RUN apt update \
 # Build/install static modules that do not have packages
 COPY mods-available /mods-available
 COPY mods-install /mods-install
-RUN for INSTALLER in /mods-install/*.sh;do \
-  /mods-install/${INSTALLER} \
-  done
+RUN for INSTALLER in /mods-install/*.sh;do ${INSTALLER} ; done
 
 RUN mkdir -p /etc/laminas-ci/problem-matcher \
     && cd /etc/laminas-ci/problem-matcher \
@@ -146,6 +144,7 @@ RUN mkdir -p /usr/local/share/composer \
     && composer global require staabm/annotate-pull-request-from-checkstyle \
     && ln -s /usr/local/share/composer/vendor/bin/cs2pr /usr/local/bin/cs2pr
 
+COPY scripts /scripts
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN useradd -ms /bin/bash testuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,27 +126,12 @@ RUN apt update \
     && npm install -g markdownlint-cli2 \
     && ln -s /usr/local/bin/markdownlint-cli2 /usr/local/bin/markdownlint
 
-# Install sqlsrv modules for PHP 7.3 - 8.0 (none available on Ubuntu 2.0.4 prior to that)
-RUN (curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so) \
-    && (curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.4.tar | tar xf - --strip-components=1 Ubuntu2004-7.4/php_pdo_sqlsrv_74_nts.so Ubuntu2004-7.4/php_sqlsrv_74_nts.so) \
-    && (curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so) \
-    && mv php_pdo_sqlsrv_73_nts.so $(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so \
-    && mv php_sqlsrv_73_nts.so $(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so \
-    && mv php_pdo_sqlsrv_74_nts.so $(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so \
-    && mv php_sqlsrv_74_nts.so $(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so \
-    && mv php_pdo_sqlsrv_80_nts.so $(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so \
-    && mv php_sqlsrv_80_nts.so $(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so 
-COPY mods-available/sqlsrv.ini /etc/php/7.3/mods-available/sqlsrv.ini
-COPY mods-available/sqlsrv.ini /etc/php/7.4/mods-available/sqlsrv.ini
-COPY mods-available/sqlsrv.ini /etc/php/8.0/mods-available/sqlsrv.ini
-
-# Install swoole modules for PHP 7.3 - 8.0
-# (we don't need to support earlier than that in mezzio-swoole)
-COPY mods-available/swoole.ini /etc/php/7.3/mods-available/swoole.ini
-COPY mods-available/swoole.ini /etc/php/7.4/mods-available/swoole.ini
-COPY mods-available/swoole.ini /etc/php/8.0/mods-available/swoole.ini
-COPY scripts/install_swoole.sh /tmp/install_swoole.sh
-RUN /tmp/install_swoole.sh && rm /tmp/install_swoole.sh
+# Build/install static modules that do not have packages
+COPY mods-available /mods-available
+COPY mods-install /mods-install
+RUN for INSTALLER in /mods-install/*.sh;do \
+  /mods-install/${INSTALLER} \
+  done
 
 RUN mkdir -p /etc/laminas-ci/problem-matcher \
     && cd /etc/laminas-ci/problem-matcher \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -149,39 +149,7 @@ DEPS=$(echo "${JOB}" | jq -r '.dependencies // "locked"')
 IGNORE_PLATFORM_REQS_ON_8=$(echo "${JOB}" | jq -r 'if has("ignore_platform_reqs_8") | not then "yes" elif .ignore_platform_reqs_8 then "yes" else "no" end')
 
 if [[ "${EXTENSIONS}" != "" ]];then
-	ENABLE_SQLSRV=false
-	if [[ "${EXTENSIONS}" =~ sqlsrv ]];then
-		if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
-			echo "Skipping enabling of sqlsrv extensions; not supported on PHP < 7.3"
-		else
-			ENABLE_SQLSRV=true
-		fi
-		EXTENSIONS=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
-	fi
-
-	ENABLE_SWOOLE=false
-	if [[ "${EXTENSIONS}" =~ swoole ]];then
-		if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
-			echo "Skipping enabling of swoole extension; not supported on PHP < 7.3"
-		else
-			ENABLE_SWOOLE=true
-		fi
-		EXTENSIONS=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
-	fi
-
-    echo "Installing extensions: ${EXTENSIONS}"
-    apt update
-    apt install -y "${EXTENSIONS}"
-
-	if [[ "${ENABLE_SQLSRV}" == "true" ]];then
-		echo "Enabling sqlsrv extensions"
-		phpenmod -v "${PHP}" -s ALL sqlsrv
-	fi
-
-	if [[ "${ENABLE_SWOOLE}" == "true" ]];then
-		echo "Enabling swoole extensions"
-		phpenmod -v "${PHP}" -s ALL swoole
-	fi
+    /scripts/extensions.sh "${PHP}" "${EXTENSIONS}"
 fi
 
 if [[ "${INI}" != "" ]];then

--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -10,14 +10,14 @@ curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu200
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so
 
 # Copy extensions to appropriate locations for each PHP version
-mv php_pdo_sqlsrv_73_nts.so $(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so
-mv php_sqlsrv_73_nts.so $(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so
-mv php_pdo_sqlsrv_74_nts.so $(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so
-mv php_sqlsrv_74_nts.so $(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so
-mv php_pdo_sqlsrv_80_nts.so $(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so
-mv php_sqlsrv_80_nts.so $(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so 
+mv php_pdo_sqlsrv_73_nts.so "$(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
+mv php_sqlsrv_73_nts.so "$(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
+mv php_pdo_sqlsrv_74_nts.so "$(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
+mv php_sqlsrv_74_nts.so "$(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
+mv php_pdo_sqlsrv_80_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
+mv php_sqlsrv_80_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
 
 # Copy conf file to appropriate locations
 for PHP_VERSION in 7.3 7.4 8.0;do
-    cp /mods-available/sqlsrv.ini /etc/php/${PHP_VERSION}/mods-available/sqlsrv.ini
+    cp /mods-available/sqlsrv.ini "/etc/php/${PHP_VERSION}/mods-available/sqlsrv.ini"
 done

--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+cd tmp
+
+# Download extension versions from MS
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.4.tar | tar xf - --strip-components=1 Ubuntu2004-7.4/php_pdo_sqlsrv_74_nts.so Ubuntu2004-7.4/php_sqlsrv_74_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so
+
+# Copy extensions to appropriate locations for each PHP version
+mv php_pdo_sqlsrv_73_nts.so $(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so
+mv php_sqlsrv_73_nts.so $(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so
+mv php_pdo_sqlsrv_74_nts.so $(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so
+mv php_sqlsrv_74_nts.so $(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so
+mv php_pdo_sqlsrv_80_nts.so $(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so
+mv php_sqlsrv_80_nts.so $(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so 
+
+# Copy conf file to appropriate locations
+for PHP_VERSION in 7.3 7.4 8.0;do
+    cp /mods-available/sqlsrv.ini /etc/php/${PHP_VERSION}/mods-available/sqlsrv.ini
+done

--- a/mods-install/install_swoole.sh
+++ b/mods-install/install_swoole.sh
@@ -24,3 +24,8 @@ done
 # Cleanup
 rm -rf /tmp/swoole-${SWOOLE_VERSION}
 rm /tmp/swoole-${SWOOLE_VERSION}.tgz
+
+# Copy conf file to appropriate locations
+for PHP_VERSION in 7.3 7.4 8.0;do
+    cp /mods-available/swoole.ini /etc/php/${PHP_VERSION}/mods-available/swoole.ini
+done

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -74,6 +74,6 @@ for EXTENSION in "${STATIC_EXTENSIONS[@]}";do
 done
 
 # If by now the extensions list is not empty, install packaged extensions.
-if [[ "${EXTENSIONS[*]}" != "" ]];then
+if [[ ${#EXTENSIONS[@]} != 0 ]];then
     install_packaged_extensions "${EXTENSIONS[@]}"
 fi

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Install and/or enable extensions.
+# Usage:
+#
+#   extensions.sh PHP_VERSION LIST_OF_EXTENSIONS
+
+set -e
+
+STATIC_EXTENSIONS=(sqlsrv swoole)
+
+function install_packaged_extensions {
+    local EXTENSIONS=${@:1}
+    echo "Installing packaged extensions: ${EXTENSIONS}"
+    apt update
+    apt install -y "${EXTENSIONS}"
+}
+
+function enable_static_extension {
+    local PHP=$1
+    local EXTENSION=$2
+    echo "Enabling ${EXTENSION} extension"
+    phpenmod -v "${PHP}" -s ALL "${EXTENSION}"
+}
+
+function enable_sqlsrv {
+    local __result=$1
+    local PHP=$2
+    local EXTENSIONS=${@:3}
+    if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
+        echo "Skipping enabling of swoole extension; not supported on PHP < 7.3"
+        eval $__result="${EXTENSIONS}"
+    else
+        enable_static_extension "${PHP}" sqlsrv
+		eval $__result=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
+    fi
+}
+
+function enable_swoole {
+    local __result=$1
+    local PHP=$2
+    local EXTENSIONS=${@:3}
+    if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
+        echo "Skipping enabling of swoole extension; not supported on PHP < 7.3"
+        eval $__result="${EXTENSIONS}"
+    else
+        enable_static_extension "${PHP}" swoole
+        eval $__result=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
+    fi
+}
+
+PHP=$1
+EXTENSIONS=${@:2}
+
+# Loop through known statically compiled/installed extensions, and enable them.
+# Each should update the result variable passed to it with a new list of
+# extensions.
+for EXTENSION in "${STATIC_EXTENSIONS[@]}";do
+    if [[ "${EXTENSIONS}" =~ ${EXTENSION} ]];then
+        ENABLE_FUNC="enable_${EXTENSION}"
+        $ENABLE_FUNC result "${PHP}" "${EXTENSIONS}"
+        EXTENSIONS="${result}"
+    fi
+done
+
+# If by now the extensions list is not empty, install packaged extensions.
+if [[ "${EXTENSIONS}" != "" ]];then
+    install_packaged_extensions "${EXTENSIONS}"
+fi

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -9,15 +9,19 @@ set -e
 STATIC_EXTENSIONS=(sqlsrv swoole)
 
 function install_packaged_extensions {
-    local EXTENSIONS=${@:1}
-    echo "Installing packaged extensions: ${EXTENSIONS}"
+    local -a EXTENSIONS=("${@:1}")
+    local TO_INSTALL="${EXTENSIONS[*]}"
+
+    echo "Installing packaged extensions: ${TO_INSTALL}"
     apt update
-    apt install -y "${EXTENSIONS}"
+    # shellcheck disable=SC2086,SC2046
+    apt install -y ${TO_INSTALL}
 }
 
 function enable_static_extension {
     local PHP=$1
     local EXTENSION=$2
+
     echo "Enabling ${EXTENSION} extension"
     phpenmod -v "${PHP}" -s ALL "${EXTENSION}"
 }
@@ -25,44 +29,51 @@ function enable_static_extension {
 function enable_sqlsrv {
     local __result=$1
     local PHP=$2
-    local EXTENSIONS=${@:3}
+    local -a EXTENSIONS=("${@:3}")
+    local TO_RETURN
+
     if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
-        echo "Skipping enabling of swoole extension; not supported on PHP < 7.3"
-        eval $__result="${EXTENSIONS}"
+        echo "Skipping enabling of sqlsrv extension; not supported on PHP < 7.3"
     else
         enable_static_extension "${PHP}" sqlsrv
-		eval $__result=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
     fi
+
+    TO_RETURN=$(echo "${EXTENSIONS[@]}" | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
+    eval "$__result='$TO_RETURN'"
 }
 
 function enable_swoole {
     local __result=$1
     local PHP=$2
-    local EXTENSIONS=${@:3}
+    local -a EXTENSIONS=("${@:3}")
+    local TO_RETURN
+
     if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
         echo "Skipping enabling of swoole extension; not supported on PHP < 7.3"
-        eval $__result="${EXTENSIONS}"
     else
         enable_static_extension "${PHP}" swoole
-        eval $__result=$(echo "${EXTENSIONS}" | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
     fi
+
+    TO_RETURN=$(echo "${EXTENSIONS[@]}" | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
+    eval "$__result='$TO_RETURN'"
 }
 
 PHP=$1
-EXTENSIONS=${@:2}
+EXTENSIONS=("${@:2}")
+declare result
 
 # Loop through known statically compiled/installed extensions, and enable them.
 # Each should update the result variable passed to it with a new list of
 # extensions.
 for EXTENSION in "${STATIC_EXTENSIONS[@]}";do
-    if [[ "${EXTENSIONS}" =~ ${EXTENSION} ]];then
+    if [[ "${EXTENSIONS[*]}" =~ ${EXTENSION} ]];then
         ENABLE_FUNC="enable_${EXTENSION}"
-        $ENABLE_FUNC result "${PHP}" "${EXTENSIONS}"
-        EXTENSIONS="${result}"
+        $ENABLE_FUNC result "${PHP}" "${EXTENSIONS[*]}"
+        EXTENSIONS=("${result}")
     fi
 done
 
 # If by now the extensions list is not empty, install packaged extensions.
-if [[ "${EXTENSIONS}" != "" ]];then
-    install_packaged_extensions "${EXTENSIONS}"
+if [[ "${EXTENSIONS[*]}" != "" ]];then
+    install_packaged_extensions "${EXTENSIONS[@]}"
 fi


### PR DESCRIPTION
This patch accomplishes three (related) things.

First, it now adds the mods-available directory to the container.

Second, it creates a "mods-install" directory with installation scripts for manually adding/compiling extensions, moving the previous one for installing swoole to the directory, and splitting out the one from the Dockerfile for enabling sqlsrv. Each script also moves the appropriate mods-available INI to the appropriate PHP version configuration directories. The Dockerfile now loops through the mods-install scripts, executing each, in a single build step.

Third, it splits out the logic for enabling extensions from the entrypoint script to a new `/scripts/extensions.sh` script. This will allow us to gradually add routines specific to enabling modules without convoluting the logic of the entrypoint further. It also makes it easier to see the logic specific to each extension, as each is encapsulated in a single function.
