### PR TITLE
Use development php.ini settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ RUN mkdir -p /usr/local/share/composer \
     && ln -s /usr/local/share/composer/vendor/bin/cs2pr /usr/local/bin/cs2pr
 
 COPY scripts /scripts
+RUN /scripts/php_ini_dev_settings.sh
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN useradd -ms /bin/bash testuser

--- a/scripts/php_ini_dev_settings.sh
+++ b/scripts/php_ini_dev_settings.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+declare -a SUBSTITUTIONS
+
+SUBSTITUTIONS+=('s/zend.exception_ignore_args ?= ?(On|Off)/zend.exception_ignore_args = Off/')
+SUBSTITUTIONS+=('s/zend.exception_string_param_max_len ?= ?[0-9]+/zend.exception_string_param_max_len = 15/')
+SUBSTITUTIONS+=('s/error_reporting ?= ?[A-Z_~ &]+/error_reporting = E_ALL/')
+SUBSTITUTIONS+=('s/display_errors ?= ?(On|Off)/display_errors = On/')
+SUBSTITUTIONS+=('s/display_startup_errors ?= ?(On|Off)/display_startup_errors = On/')
+SUBSTITUTIONS+=('s/mysqlnd.collect_memory_statistics ?= ?(On|Off)/mysqlnd.collect_memory_statistics = On/')
+SUBSTITUTIONS+=('s/zend.assertions ?= ?(-1|1)/zend.assertions = 1/')
+SUBSTITUTIONS+=('s/opcache.huge_code_pages ?= ?(0|1)/opcache.huge_code_pages = 0/')
+
+for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0;do
+    INI_FILE="/etc/php/${PHP_VERSION}/cli/php.ini"
+    for SUBSTITUTION in "${SUBSTITUTIONS[@]}";do
+        sed --in-place -E -e "${SUBSTITUTION}" "${INI_FILE}"
+    done
+done


### PR DESCRIPTION
This patch updates the base `php.ini` for each PHP version to provide the following develoment values (assuming that the version supports the setting):

- `zend.exception_ignore_args = Off`
- `zend.exception_string_param_max_len = 15`
- `error_reporting = E_ALL`
- `display_errors = On`
- `display_startup_errors = On`
- `mysqlnd.collect_memory_statistics = On`
- `zend.assertions = 1`

Fixes #36
