### PR TITLE
Improve build times by caching layers, when possible

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -40,6 +40,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
+          pull: true
           push: true
           tags: ${{ join(fromJSON(steps.tags.outputs.tags), ',') }}
           cache-from: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -3,10 +3,13 @@ name: Build and push containers
 on:
   release:
     types: [published]
+  pull_request:
 
 jobs:
   release-container:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USER: ${{ secrets.CONTAINER_USERNAME }}
     steps:
       - name: Compile tag list
         id: tags
@@ -28,13 +31,15 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to GitHub Container Registry
+        if: ${{ env.DOCKER_USER }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.CONTAINER_USERNAME }}
+          username: ${{ env.DOCKER_USER }}
           password: ${{ secrets.CONTAINER_PAT }}
 
-      - name: Build and push
+      - name: Build and push for release
+        if: ${{ github.event_name == 'release' }}
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -45,3 +50,26 @@ jobs:
           tags: ${{ join(fromJSON(steps.tags.outputs.tags), ',') }}
           cache-from: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache
           cache-to: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache,mode=max
+
+      - name: Build for local pull request
+        if: ${{ github.event_name == 'pull_request' && env.DOCKER_USER }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          pull: true
+          push: false
+          cache-from: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache
+          cache-to: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache,mode=max
+
+      - name: Build for fork pull request
+        if: ${{ github.event_name == 'pull_request' && ! env.DOCKER_USER }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          pull: true
+          push: false
+          cache-from: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -42,3 +42,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ join(fromJSON(steps.tags.outputs.tags), ',') }}
+          cache-from: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache
+          cache-to: type=registry,ref=ghcr.io/laminas/laminas-continuous-integration-action:build-cache,mode=max

--- a/README.md
+++ b/README.md
@@ -248,3 +248,19 @@ The container provides the following tools:
 - A `yamllint` binary, via the [adrienverge/yamllint](https://github.com/adrienverge/yamllint) package.
 
 - The [jq](https://stedolan.github.io/jq/) command, a CLI JSON processor.
+
+## Notes on contributing
+
+This package includes a workflow that will build the container during pull request, to verify that builds complete successfully.
+
+The workflow has three different conditional build steps:
+
+- One that happens only on release; this is irrelevant to pull requests.
+- Two that happen for pull requests:
+  - One that triggers if the repository's `CONTAINER_USERNAME` (and, by extension, `CONTAINER_PAT`) secret is present.
+  - One that triggers if the repository's `CONTAINER_USERNAME` (and, by extension, `CONTAINER_PAT`) secret is NOT present.
+
+In the case where the repository secrets are present, the build will also cache layers it has built, which will speed up later builds.
+However, because repository secrets are not provided when a pull request is performed from a forked repository, the second case will kick in; in that scenario, the build will still run, but no layers will be pushed to the container registry.
+
+As such, if you are a Laminas Technical Steering Committee member or a maintainer with write access to this repository, please submit your patches via branches pushed directly to the repository, as this will speed up builds for everyone.


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

By using `ghcr.io/laminas/laminas-continuous-integration-action:build-cache` as a registry-based
docker image layer cache, we can avoid re-building any intermediate docker image layers for which
an exact SHA256 match exists.

This will dramatically speed up builds that happen to change little within the `Dockerfile` (or
any related sources), and it will reduce any network I/O failures caused by upstream package manager
hiccups.

Note that random users cannot just push to the cache: active caching can only happen when operating
within the boundaries of the `laminas/*` organization (direct repository pushes, operations performed
by maintainers).

To prevent stale images due to caching, we do a full re-build when the base image changes: it's an acceptable
cost, for something that changes less frequently, while we still retain caching advantages
when multiple pushes are performed close to each other.