### PR TITLE
Output PHP extensions with version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,7 @@ RUN mkdir -p /usr/local/share/composer \
 COPY scripts /scripts
 RUN /scripts/php_ini_dev_settings.sh
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY php-extensions-with-version.php /usr/local/bin/php-extensions-with-version.php
 
 RUN useradd -ms /bin/bash testuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,6 +148,7 @@ COPY scripts /scripts
 RUN /scripts/php_ini_dev_settings.sh
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY php-extensions-with-version.php /usr/local/bin/php-extensions-with-version.php
+RUN chmod +x /usr/local/bin/php-extensions-with-version.php
 
 RUN useradd -ms /bin/bash testuser
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -162,7 +162,7 @@ fi
 
 echo "PHP version: $(php --version)"
 echo "Installed extensions:"
-php -m
+/usr/local/bin/php-extensions-with-version.php
 
 # If a token is present, tell Composer about it so we can avoid rate limits
 if [[ "${GITHUB_TOKEN}" != "" ]];then

--- a/php-extensions-with-version.php
+++ b/php-extensions-with-version.php
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+
+foreach (get_loaded_extensions() as $extension) {
+    $version = phpversion($extension);
+
+    printf('%s: %s%s', $extension, $version, PHP_EOL);
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

I am currently implementing PHP 8.0 support for `laminas/laminas-cache-storage-adapter-memcached`.
I've executed tests locally where all of them passed on PHP 8.0.
When running within the container of laminas-ci, it fails.

Maybe this has something to do with the extension version the container is using and thus, I'd like to see which version is currently built into the container.