### PR TITLE
Initial PHP 8.1 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,123 +8,30 @@ LABEL "maintainer"="https://github.com/laminas/technical-steering-committee/"
 
 ENV COMPOSER_HOME=/usr/local/share/composer
 
-RUN apt update \
-    && apt install -y software-properties-common curl \
-    && (curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -) \
-    && add-apt-repository -y ppa:ondrej/php \
-    && add-apt-repository -y https://packages.microsoft.com/ubuntu/20.04/prod \
-    && ACCEPT_EULA=Y apt install -y \
-        git \
-        jq \
-        libxml2-utils \
-        libzip-dev \
-        npm \
-        sudo \
-        wget \
-        yamllint \
-        zip \
-        msodbcsql17 \
-        php5.6-bz2 \
-        php5.6-cli \
-        php5.6-curl \
-        php5.6-dev \
-        php5.6-fileinfo \
-        php5.6-intl \
-        php5.6-json \
-        php5.6-mbstring \
-        php5.6-phar \
-        php5.6-readline \
-        php5.6-sockets \
-        php5.6-xml \
-        php5.6-xsl \
-        php5.6-zip \
-        php7.0-cli \
-        php7.0-bz2 \
-        php7.0-curl \
-        php7.0-dev \
-        php7.0-fileinfo \
-        php7.0-intl \
-        php7.0-json \
-        php7.0-mbstring \
-        php7.0-phar \
-        php7.0-readline \
-        php7.0-sockets \
-        php7.0-xml \
-        php7.0-xsl \
-        php7.0-zip \
-        php7.1-cli \
-        php7.1-bz2 \
-        php7.1-curl \
-        php7.1-dev \
-        php7.1-fileinfo \
-        php7.1-intl \
-        php7.1-json \
-        php7.1-mbstring \
-        php7.1-phar \
-        php7.1-readline \
-        php7.1-sockets \
-        php7.1-xml \
-        php7.1-xsl \
-        php7.1-zip \
-        php7.2-cli \
-        php7.2-bz2 \
-        php7.2-curl \
-        php7.2-dev \
-        php7.2-fileinfo \
-        php7.2-intl \
-        php7.2-json \
-        php7.2-mbstring \
-        php7.2-phar \
-        php7.2-readline \
-        php7.2-sockets \
-        php7.2-xml \
-        php7.2-xsl \
-        php7.2-zip \
-        php7.3-cli \
-        php7.3-bz2 \
-        php7.3-curl \
-        php7.3-dev \
-        php7.3-fileinfo \
-        php7.3-intl \
-        php7.3-json \
-        php7.3-mbstring \
-        php7.3-phar \
-        php7.3-readline \
-        php7.3-sockets \
-        php7.3-xml \
-        php7.3-xsl \
-        php7.3-zip \
-        php7.4-cli \
-        php7.4-bz2 \
-        php7.4-curl \
-        php7.4-dev \
-        php7.4-fileinfo \
-        php7.4-intl \
-        php7.4-json \
-        php7.4-mbstring \
-        php7.4-phar \
-        php7.4-readline \
-        php7.4-sockets \
-        php7.4-xml \
-        php7.4-xsl \
-        php7.4-zip \
-        php8.0-cli \
-        php8.0-bz2 \
-        php8.0-curl \
-        php8.0-dev \
-        php8.0-fileinfo \
-        php8.0-intl \
-        php8.0-mbstring \
-        php8.0-phar \
-        php8.0-readline \
-        php8.0-sockets \
-        php8.0-xml \
-        php8.0-xsl \
-        php8.0-zip \
-    && apt clean \
-    && update-alternatives --set php /usr/bin/php7.4 \
-    && npm install -g markdownlint-cli2 \
-    && ln -s /usr/local/bin/markdownlint-cli2 /usr/local/bin/markdownlint
+COPY setup /setup
+# Base setup
+RUN cd /setup/ubuntu && bash setup.sh
+
+# Markdownlint
+RUN cd /setup/markdownlint && bash setup.sh
+
+# PHP
+RUN cd /setup/php/5.6 && bash setup.sh
+RUN cd /setup/php/7.0 && bash setup.sh
+RUN cd /setup/php/7.1 && bash setup.sh
+RUN cd /setup/php/7.2 && bash setup.sh
+RUN cd /setup/php/7.3 && bash setup.sh
+RUN cd /setup/php/7.4 && bash setup.sh
+RUN cd /setup/php/8.0 && bash setup.sh
+
+# Set default PHP version
+RUN update-alternatives --set php /usr/bin/php7.4 \
+    && update-alternatives --set phpize /usr/bin/phpize7.4 \
+    && update-alternatives --set php-config /usr/bin/php-config7.4
+
+# Cleanup
+RUN rm -rf /setup \
+    && apt clean
 
 # Build/install static modules that do not have packages
 COPY mods-available /mods-available
@@ -145,6 +52,8 @@ RUN mkdir -p /usr/local/share/composer \
     && ln -s /usr/local/share/composer/vendor/bin/cs2pr /usr/local/bin/cs2pr
 
 COPY scripts /scripts
+RUN chmod a+x /scripts/*
+
 RUN /scripts/php_ini_dev_settings.sh
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN cd /setup/php/7.2 && bash setup.sh
 RUN cd /setup/php/7.3 && bash setup.sh
 RUN cd /setup/php/7.4 && bash setup.sh
 RUN cd /setup/php/8.0 && bash setup.sh
+RUN cd /setup/php/8.1 && bash setup.sh
 
 # Set default PHP version
 RUN update-alternatives --set php /usr/bin/php7.4 \

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The tricks to remember are:
 As an example, if you wanted to run the CS checks under PHP 7.4 using locked dependencies, you could do something like the following:
 
 ```bash
-$ docker run -v $(realpath .):/github/workspace -w=/github/workspace laminas-check-runner:latest '{"php":"7.4","deps":"locked","extensions":[],"ini":["memory_limit=-1"],"command":"./vendor/bin/phpcs"}'
+$ docker run -v $(realpath .):/github/workspace -w=/github/workspace laminas-check-runner:latest '{"php":"7.4","dependencies":"locked","extensions":[],"ini":["memory_limit=-1"],"command":"./vendor/bin/phpcs"}'
 ```
 
 The trick to remember: the job JSON should generally be in single quotes, to allow the `"` characters used to delimit properties and strings in the JSON to not cause interpolation issues.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -146,7 +146,7 @@ if [ -x ".laminas-ci/pre-install.sh" ];then
     ./.laminas-ci/pre-install.sh testuser "${PWD}" "${JOB}"
 fi
 
-EXTENSIONS=$(echo "${JOB}" | jq -r ".extensions // [] | map(\"php${PHP}-\"+.) | join(\" \")")
+EXTENSIONS=$(echo "${JOB}" | jq -r ".extensions // [] | join(\" \")")
 INI=$(echo "${JOB}" | jq -r '.ini // [] | join("\n")')
 DEPS=$(echo "${JOB}" | jq -r '.dependencies // "locked"')
 IGNORE_PLATFORM_REQS_ON_8=$(echo "${JOB}" | jq -r 'if has("ignore_platform_reqs_8") | not then "yes" elif .ignore_platform_reqs_8 then "yes" else "no" end')

--- a/mods-install/install_swoole.sh
+++ b/mods-install/install_swoole.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-SWOOLE_VERSION=4.6.7
+SWOOLE_VERSION=4.7.0
 
 # Get swoole package ONCE
 cd /tmp

--- a/mods-install/install_swoole.sh
+++ b/mods-install/install_swoole.sh
@@ -19,13 +19,10 @@ for PHP_VERSION in 7.3 7.4 8.0;do
     ./configure --enable-swoole --enable-sockets --with-php-config=php-config${PHP_VERSION}
     make
     make install
+
+    cp /mods-available/swoole.ini /etc/php/${PHP_VERSION}/mods-available/swoole.ini
 done
 
 # Cleanup
 rm -rf /tmp/swoole-${SWOOLE_VERSION}
 rm /tmp/swoole-${SWOOLE_VERSION}.tgz
-
-# Copy conf file to appropriate locations
-for PHP_VERSION in 7.3 7.4 8.0;do
-    cp /mods-available/swoole.ini /etc/php/${PHP_VERSION}/mods-available/swoole.ini
-done

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -6,23 +6,36 @@
 
 set -e
 
-STATIC_EXTENSIONS=(sqlsrv swoole)
+function install_extensions {
+    local PHP=$1
+    local -a EXTENSIONS=("${@:2}")
 
-function match_in_array {
-    local NEEDLE="$1"
-    local -a ARRAY_SET=("${@:2}")
-    local item
-
-    for item in "${ARRAY_SET[@]}";do
-        [[ "${item}" =~ ${NEEDLE} ]] && return 0
-    done
-
-    return 1
+    case "$PHP" in
+        8.1)
+            echo "Cannot install extension for the current PHP version."
+            echo "Please use \".laminas-ci/pre-run.sh\" to setup specific extensions for PHP $PHP"
+            echo "Additional details can be found on https://stackoverflow.com/q/8141407"
+            echo "The following extensions were not installed: ${EXTENSIONS[@]}"
+        ;;
+        *)
+            install_packaged_extensions "$PHP" "${EXTENSIONS[@]}"
+        ;;
+    esac
 }
 
 function install_packaged_extensions {
-    local -a EXTENSIONS=("${@:1}")
-    local TO_INSTALL="${EXTENSIONS[*]}"
+    local PHP=$1
+    local -a EXTENSIONS=("${@:2}")
+    local TO_INSTALL=""
+
+    for EXTENSION in "${EXTENSIONS[@]}"; do
+        # Converting extension name to package name, e.g. php8.0-redis
+        TO_INSTALL="${TO_INSTALL}php${PHP}-$EXTENSION "
+    done
+
+    if [ -z "$TO_INSTALL" ]; then
+        return;
+    fi
 
     echo "Installing packaged extensions: ${TO_INSTALL}"
     apt update
@@ -34,64 +47,38 @@ function enable_static_extension {
     local PHP=$1
     local EXTENSION=$2
 
-    echo "Enabling ${EXTENSION} extension"
+    echo "Enabling \"${EXTENSION}\" extension"
     phpenmod -v "${PHP}" -s ALL "${EXTENSION}"
 }
 
-function enable_sqlsrv {
-    local __result=$1
-    local PHP=$2
-    local -a EXTENSIONS=("${@:3}")
-    local TO_RETURN
-
-    if [[ ! ${PHP} =~ (7.3|7.4|8.0|8.1) ]];then
-        echo "Skipping enabling of sqlsrv extension; not supported on PHP < 7.3"
-    else
-        enable_static_extension "${PHP}" sqlsrv
-    fi
-
-    TO_RETURN=$(echo "${EXTENSIONS[@]}" | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
-    eval "$__result='$TO_RETURN'"
-}
-
-function enable_swoole {
-    local __result=$1
-    local PHP=$2
-    local -a EXTENSIONS=("${@:3}")
-    local TO_RETURN
-
-    if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
-        echo "Skipping enabling of swoole extension; not supported on PHP < 7.3 || >= 8.1"
-    else
-        enable_static_extension "${PHP}" swoole
-    fi
-
-    TO_RETURN=$(echo "${EXTENSIONS[@]}" | sed -E -e 's/php[0-9.]+-swoole/ /g' | sed -E -e 's/\s{2,}/ /g')
-    eval "$__result='$TO_RETURN'"
-}
-
 PHP=$1
-EXTENSIONS=("${@:2}")
-declare result ENABLE_FUNC
+declare -a EXTENSIONS=("${@:2}")
+# shellcheck disable=SC2196
+ENABLED_EXTENSIONS=$(php -m | tr '[:upper:]' '[:lower:]' | egrep -v '^[\[]' | grep -v 'zend opcache')
+EXTENSIONS_TO_INSTALL=()
 
 # Loop through known statically compiled/installed extensions, and enable them.
-# Each should update the result variable passed to it with a new list of
-# extensions.
-for EXTENSION in "${STATIC_EXTENSIONS[@]}";do
-    if match_in_array "${EXTENSION}" "${EXTENSIONS[@]}" ; then
-        ENABLE_FUNC="enable_${EXTENSION}"
-        $ENABLE_FUNC result "${PHP}" "${EXTENSIONS[*]}"
+for EXTENSION in ${EXTENSIONS[@]}; do
 
-		# Validate that we don't have just whitespace in the list
-        if [[ -z "${result// }" ]];then
-            EXTENSIONS=()
-        else
-            EXTENSIONS=("${result}")
-        fi
+    # Check if extension is already enabled
+    # shellcheck disable=SC2236,SC2143
+    if [ ! -z "$(echo "${ENABLED_EXTENSIONS}" | grep "${EXTENSION}")" ]; then
+        echo "Extension \"$EXTENSION\" is already enabled."
+        continue;
     fi
+
+    # Check if extension is installable via `phpenmod`
+    PATH_TO_EXTENSION_CONFIG="/etc/php/${PHP}/mods-available/${EXTENSION}.ini"
+
+    if [ -e "$PATH_TO_EXTENSION_CONFIG" ]; then
+        enable_static_extension "$PHP" "${EXTENSION}"
+        continue;
+    fi
+
+    EXTENSIONS_TO_INSTALL+=("$EXTENSION")
 done
 
-# If by now the extensions list is not empty, install packaged extensions.
-if [[ ${#EXTENSIONS[@]} != 0 ]];then
-    install_packaged_extensions "${EXTENSIONS[@]}"
+# If by now the extensions list is not empty, install missing extensions.
+if [[ ${#EXTENSIONS_TO_INSTALL[@]} != 0 ]]; then
+    install_extensions "$PHP" "${EXTENSIONS_TO_INSTALL[@]}"
 fi

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -58,8 +58,8 @@ ENABLED_EXTENSIONS=$(php -m | tr '[:upper:]' '[:lower:]' | egrep -v '^[\[]' | gr
 EXTENSIONS_TO_INSTALL=()
 
 # Loop through known statically compiled/installed extensions, and enable them.
-# shellcheck disable=SC2068
-for EXTENSION in ${EXTENSIONS[@]}; do
+# NOTE: when developing on MacOS, remove the quotes while implementing your changes and re-add the quotes afterwards.
+for EXTENSION in "${EXTENSIONS[@]}"; do
 
     # Check if extension is already enabled
     # shellcheck disable=SC2236,SC2143

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -15,7 +15,7 @@ function install_extensions {
             echo "Cannot install extension for the current PHP version."
             echo "Please use \".laminas-ci/pre-run.sh\" to setup specific extensions for PHP $PHP"
             echo "Additional details can be found on https://stackoverflow.com/q/8141407"
-            echo "The following extensions were not installed: ${EXTENSIONS[@]}"
+            echo "The following extensions were not installed: ${EXTENSIONS[*]}"
         ;;
         *)
             install_packaged_extensions "$PHP" "${EXTENSIONS[@]}"
@@ -58,6 +58,7 @@ ENABLED_EXTENSIONS=$(php -m | tr '[:upper:]' '[:lower:]' | egrep -v '^[\[]' | gr
 EXTENSIONS_TO_INSTALL=()
 
 # Loop through known statically compiled/installed extensions, and enable them.
+# shellcheck disable=SC2068
 for EXTENSION in ${EXTENSIONS[@]}; do
 
     # Check if extension is already enabled

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -44,7 +44,7 @@ function enable_sqlsrv {
     local -a EXTENSIONS=("${@:3}")
     local TO_RETURN
 
-    if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
+    if [[ ! ${PHP} =~ (7.3|7.4|8.0|8.1) ]];then
         echo "Skipping enabling of sqlsrv extension; not supported on PHP < 7.3"
     else
         enable_static_extension "${PHP}" sqlsrv
@@ -61,7 +61,7 @@ function enable_swoole {
     local TO_RETURN
 
     if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
-        echo "Skipping enabling of swoole extension; not supported on PHP < 7.3"
+        echo "Skipping enabling of swoole extension; not supported on PHP < 7.3 || >= 8.1"
     else
         enable_static_extension "${PHP}" swoole
     fi

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -12,7 +12,7 @@ function install_extensions {
 
     case "$PHP" in
         8.1)
-            echo "Cannot install extension for the current PHP version."
+            echo "Cannot install extensions for the current PHP version."
             echo "Please use \".laminas-ci/pre-run.sh\" to setup specific extensions for PHP $PHP"
             echo "Additional details can be found on https://stackoverflow.com/q/8141407"
             echo "The following extensions were not installed: ${EXTENSIONS[*]}"

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -62,8 +62,8 @@ EXTENSIONS_TO_INSTALL=()
 for EXTENSION in "${EXTENSIONS[@]}"; do
 
     # Check if extension is already enabled
-    # shellcheck disable=SC2236,SC2143
-    if [ ! -z "$(echo "${ENABLED_EXTENSIONS}" | grep "${EXTENSION}")" ]; then
+    REGULAR_EXPRESSION=\\b${EXTENSION}\\b
+    if [[ "${ENABLED_EXTENSIONS}" =~ $REGULAR_EXPRESSION ]]; then
         echo "Extension \"$EXTENSION\" is already enabled."
         continue;
     fi

--- a/scripts/php_ini_dev_settings.sh
+++ b/scripts/php_ini_dev_settings.sh
@@ -13,7 +13,7 @@ SUBSTITUTIONS+=('s/mysqlnd.collect_memory_statistics ?= ?(On|Off)/mysqlnd.collec
 SUBSTITUTIONS+=('s/zend.assertions ?= ?(-1|1)/zend.assertions = 1/')
 SUBSTITUTIONS+=('s/opcache.huge_code_pages ?= ?(0|1)/opcache.huge_code_pages = 0/')
 
-for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0;do
+for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1;do
     INI_FILE="/etc/php/${PHP_VERSION}/cli/php.ini"
     for SUBSTITUTION in "${SUBSTITUTIONS[@]}";do
         sed --in-place -E -e "${SUBSTITUTION}" "${INI_FILE}"

--- a/setup/markdownlint/setup.sh
+++ b/setup/markdownlint/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+NODE_ENV=production npm install -g markdownlint-cli2
+ln -s /usr/local/bin/markdownlint-cli2 /usr/local/bin/markdownlint

--- a/setup/php/5.6/dependencies
+++ b/setup/php/5.6/dependencies
@@ -1,0 +1,14 @@
+php5.6-bz2
+php5.6-cli
+php5.6-curl
+php5.6-dev
+php5.6-fileinfo
+php5.6-intl
+php5.6-json
+php5.6-mbstring
+php5.6-phar
+php5.6-readline
+php5.6-sockets
+php5.6-xml
+php5.6-xsl
+php5.6-zip

--- a/setup/php/5.6/setup.sh
+++ b/setup/php/5.6/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ACCEPT_EULA=Y xargs -a dependencies apt install -y

--- a/setup/php/7.0/dependencies
+++ b/setup/php/7.0/dependencies
@@ -1,0 +1,14 @@
+php7.0-cli
+php7.0-bz2
+php7.0-curl
+php7.0-dev
+php7.0-fileinfo
+php7.0-intl
+php7.0-json
+php7.0-mbstring
+php7.0-phar
+php7.0-readline
+php7.0-sockets
+php7.0-xml
+php7.0-xsl
+php7.0-zip

--- a/setup/php/7.0/setup.sh
+++ b/setup/php/7.0/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ACCEPT_EULA=Y xargs -a dependencies apt install -y

--- a/setup/php/7.1/dependencies
+++ b/setup/php/7.1/dependencies
@@ -1,0 +1,14 @@
+php7.1-cli
+php7.1-bz2
+php7.1-curl
+php7.1-dev
+php7.1-fileinfo
+php7.1-intl
+php7.1-json
+php7.1-mbstring
+php7.1-phar
+php7.1-readline
+php7.1-sockets
+php7.1-xml
+php7.1-xsl
+php7.1-zip

--- a/setup/php/7.1/setup.sh
+++ b/setup/php/7.1/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ACCEPT_EULA=Y xargs -a dependencies apt install -y

--- a/setup/php/7.2/dependencies
+++ b/setup/php/7.2/dependencies
@@ -1,0 +1,14 @@
+php7.2-cli
+php7.2-bz2
+php7.2-curl
+php7.2-dev
+php7.2-fileinfo
+php7.2-intl
+php7.2-json
+php7.2-mbstring
+php7.2-phar
+php7.2-readline
+php7.2-sockets
+php7.2-xml
+php7.2-xsl
+php7.2-zip

--- a/setup/php/7.2/setup.sh
+++ b/setup/php/7.2/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ACCEPT_EULA=Y xargs -a dependencies apt install -y

--- a/setup/php/7.3/dependencies
+++ b/setup/php/7.3/dependencies
@@ -1,0 +1,14 @@
+php7.3-cli
+php7.3-bz2
+php7.3-curl
+php7.3-dev
+php7.3-fileinfo
+php7.3-intl
+php7.3-json
+php7.3-mbstring
+php7.3-phar
+php7.3-readline
+php7.3-sockets
+php7.3-xml
+php7.3-xsl
+php7.3-zip

--- a/setup/php/7.3/setup.sh
+++ b/setup/php/7.3/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ACCEPT_EULA=Y xargs -a dependencies apt install -y

--- a/setup/php/7.4/dependencies
+++ b/setup/php/7.4/dependencies
@@ -1,0 +1,14 @@
+php7.4-cli
+php7.4-bz2
+php7.4-curl
+php7.4-dev
+php7.4-fileinfo
+php7.4-intl
+php7.4-json
+php7.4-mbstring
+php7.4-phar
+php7.4-readline
+php7.4-sockets
+php7.4-xml
+php7.4-xsl
+php7.4-zip

--- a/setup/php/7.4/setup.sh
+++ b/setup/php/7.4/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ACCEPT_EULA=Y xargs -a dependencies apt install -y

--- a/setup/php/8.0/dependencies
+++ b/setup/php/8.0/dependencies
@@ -1,0 +1,13 @@
+php8.0-cli
+php8.0-bz2
+php8.0-curl
+php8.0-dev
+php8.0-fileinfo
+php8.0-intl
+php8.0-mbstring
+php8.0-phar
+php8.0-readline
+php8.0-sockets
+php8.0-xml
+php8.0-xsl
+php8.0-zip

--- a/setup/php/8.0/setup.sh
+++ b/setup/php/8.0/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ACCEPT_EULA=Y xargs -a dependencies apt install -y

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+curl -sSLO https://github.com/shivammathur/php-builder/releases/latest/download/install.sh
+chmod a+x ./install.sh
+./install.sh 8.1
+
+# Setup directory structure
+CONFIGURATION_DIRECTORY_PREFIX="/usr/local/php/8.1/etc"
+
+rm -rf /etc/php/8.1
+mkdir -p /etc/php/8.1/{cli,mods-available}
+ln -s $CONFIGURATION_DIRECTORY_PREFIX/php.ini /etc/php/8.1/cli/
+ln -s $CONFIGURATION_DIRECTORY_PREFIX/conf.d /etc/php/8.1/cli/conf.d
+for mod in $(ls /etc/php/8.1/cli/conf.d); do
+    modWithoutPriority=$(echo $mod | cut -d'-' -f2-)
+    modname=$(echo $modWithoutPriority | cut -d'.' -f1)
+
+    mv /etc/php/8.1/cli/conf.d/$mod /etc/php/8.1/mods-available/$modWithoutPriority
+
+    case "$modname" in
+        "xdebug" | "sqlsrv" | "pdo_sqlsrv")
+            # Do not enable these modules as default
+        ;;
+        *)
+            ln -s /etc/php/8.1/mods-available/$modWithoutPriority /etc/php/8.1/cli/conf.d/$mod
+        ;;
+    esac
+done
+
+# Prepares the configuration the same way as mods-install/install_sqlsrv.sh would do
+cat /etc/php/8.1/mods-available/pdo_sqlsrv.ini >> /etc/php/8.1/mods-available/sqlsrv.ini
+rm /etc/php/8.1/mods-available/pdo_sqlsrv.ini

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -11,8 +11,8 @@ rm -rf /etc/php/8.1
 mkdir -p /etc/php/8.1/{cli,mods-available}
 ln -s $CONFIGURATION_DIRECTORY_PREFIX/php.ini /etc/php/8.1/cli/
 ln -s $CONFIGURATION_DIRECTORY_PREFIX/conf.d /etc/php/8.1/cli/conf.d
-for mod in $(ls /etc/php/8.1/cli/conf.d); do
-    modWithoutPriority=$(echo $mod | cut -d'-' -f2-)
+for mod in /etc/php/8.1/cli/conf.d/*; do
+    modWithoutPriority=$(echo $(basename $mod) | cut -d'-' -f2-)
     modname=$(echo $modWithoutPriority | cut -d'.' -f1)
 
     mv /etc/php/8.1/cli/conf.d/$mod /etc/php/8.1/mods-available/$modWithoutPriority
@@ -22,7 +22,7 @@ for mod in $(ls /etc/php/8.1/cli/conf.d); do
             # Do not enable these modules as default
         ;;
         *)
-            ln -s /etc/php/8.1/mods-available/$modWithoutPriority /etc/php/8.1/cli/conf.d/$mod
+            ln -s /etc/php/8.1/mods-available/$modWithoutPriority $mod
         ;;
     esac
 done

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -4,25 +4,16 @@ curl -sSLO https://github.com/shivammathur/php-builder/releases/latest/download/
 chmod a+x ./install.sh
 ./install.sh 8.1
 
-# Setup directory structure
-CONFIGURATION_DIRECTORY_PREFIX="/usr/local/php/8.1/etc"
-
-rm -rf /etc/php/8.1
-mkdir -p /etc/php/8.1/{cli,mods-available}
-ln -s $CONFIGURATION_DIRECTORY_PREFIX/php.ini /etc/php/8.1/cli/
-ln -s $CONFIGURATION_DIRECTORY_PREFIX/conf.d /etc/php/8.1/cli/conf.d
+# Keep modules we do have in PHP 8.0 as well while disabling all other modules
 for mod in /etc/php/8.1/cli/conf.d/*; do
     modWithoutPriority=$(echo $(basename $mod) | cut -d'-' -f2-)
     modname=$(echo $modWithoutPriority | cut -d'.' -f1)
 
-    mv $mod /etc/php/8.1/mods-available/$modWithoutPriority
-
     case "$modname" in
-        "xdebug" | "sqlsrv" | "pdo_sqlsrv")
-            # Do not enable these modules as default
+        "bz2" | "calendar" | "ctype" | "curl" | "dom" | "exif" | "ffi" | "fileinfo" | "ftp" | "gettext" | "iconv" | "intl" | "mbstring" | "opcache" | "pdo" | "phar" | "posix" | "readline" | "shmop" | "simplexml" | "sockets" | "sysvmsg" | "sysvsem" | "sysvshm" | "tokenizer" | "xml" | "xmlreader" | "xmlwriter" | "xsl" | "zip")
         ;;
         *)
-            ln -s /etc/php/8.1/mods-available/$modWithoutPriority $mod
+            rm $mod
         ;;
     esac
 done

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -4,20 +4,6 @@ curl -sSLO https://github.com/shivammathur/php-builder/releases/latest/download/
 chmod a+x ./install.sh
 ./install.sh 8.1
 
-# Keep modules we do have in PHP 8.0 as well while disabling all other modules
-for moduleIniSettings in /etc/php/8.1/cli/conf.d/*; do
-    # shellcheck disable=SC2005
-    moduleName=$(echo "$(basename "$(readlink "$moduleIniSettings")")" | cut -d '.' -f1)
-
-    case "$moduleName" in
-        "bz2" | "calendar" | "ctype" | "curl" | "dom" | "exif" | "ffi" | "fileinfo" | "ftp" | "gettext" | "iconv" | "intl" | "mbstring" | "opcache" | "pdo" | "phar" | "posix" | "readline" | "shmop" | "simplexml" | "sockets" | "sysvmsg" | "sysvsem" | "sysvshm" | "tokenizer" | "xml" | "xmlreader" | "xmlwriter" | "xsl" | "zip")
-        ;;
-        *)
-            rm "$moduleIniSettings"
-        ;;
-    esac
-done
-
 # Prepares the configuration the same way as mods-install/install_sqlsrv.sh would do
 cat /etc/php/8.1/mods-available/pdo_sqlsrv.ini >> /etc/php/8.1/mods-available/sqlsrv.ini
 rm /etc/php/8.1/mods-available/pdo_sqlsrv.ini

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -5,15 +5,14 @@ chmod a+x ./install.sh
 ./install.sh 8.1
 
 # Keep modules we do have in PHP 8.0 as well while disabling all other modules
-for mod in /etc/php/8.1/cli/conf.d/*; do
-    modWithoutPriority=$(echo $(basename $mod) | cut -d'-' -f2-)
-    modname=$(echo $modWithoutPriority | cut -d'.' -f1)
+for moduleIniSettings in /etc/php/8.1/cli/conf.d/*; do
+    moduleName=$(echo "$(basename $(readlink $moduleIniSettings))" | cut -d '.' -f1)
 
-    case "$modname" in
+    case "$moduleName" in
         "bz2" | "calendar" | "ctype" | "curl" | "dom" | "exif" | "ffi" | "fileinfo" | "ftp" | "gettext" | "iconv" | "intl" | "mbstring" | "opcache" | "pdo" | "phar" | "posix" | "readline" | "shmop" | "simplexml" | "sockets" | "sysvmsg" | "sysvsem" | "sysvshm" | "tokenizer" | "xml" | "xmlreader" | "xmlwriter" | "xsl" | "zip")
         ;;
         *)
-            rm $mod
+            rm "$moduleIniSettings"
         ;;
     esac
 done

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -6,7 +6,7 @@ chmod a+x ./install.sh
 
 # Keep modules we do have in PHP 8.0 as well while disabling all other modules
 for moduleIniSettings in /etc/php/8.1/cli/conf.d/*; do
-    moduleName=$(echo "$(basename $(readlink $moduleIniSettings))" | cut -d '.' -f1)
+    moduleName=$(echo "$(basename $(readlink "$moduleIniSettings"))" | cut -d '.' -f1)
 
     case "$moduleName" in
         "bz2" | "calendar" | "ctype" | "curl" | "dom" | "exif" | "ffi" | "fileinfo" | "ftp" | "gettext" | "iconv" | "intl" | "mbstring" | "opcache" | "pdo" | "phar" | "posix" | "readline" | "shmop" | "simplexml" | "sockets" | "sysvmsg" | "sysvsem" | "sysvshm" | "tokenizer" | "xml" | "xmlreader" | "xmlwriter" | "xsl" | "zip")

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -15,7 +15,7 @@ for mod in /etc/php/8.1/cli/conf.d/*; do
     modWithoutPriority=$(echo $(basename $mod) | cut -d'-' -f2-)
     modname=$(echo $modWithoutPriority | cut -d'.' -f1)
 
-    mv /etc/php/8.1/cli/conf.d/$mod /etc/php/8.1/mods-available/$modWithoutPriority
+    mv $mod /etc/php/8.1/mods-available/$modWithoutPriority
 
     case "$modname" in
         "xdebug" | "sqlsrv" | "pdo_sqlsrv")

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -6,7 +6,8 @@ chmod a+x ./install.sh
 
 # Keep modules we do have in PHP 8.0 as well while disabling all other modules
 for moduleIniSettings in /etc/php/8.1/cli/conf.d/*; do
-    moduleName=$(echo "$(basename $(readlink "$moduleIniSettings"))" | cut -d '.' -f1)
+    # shellcheck disable=SC2005
+    moduleName=$(echo "$(basename "$(readlink "$moduleIniSettings")")" | cut -d '.' -f1)
 
     case "$moduleName" in
         "bz2" | "calendar" | "ctype" | "curl" | "dom" | "exif" | "ffi" | "fileinfo" | "ftp" | "gettext" | "iconv" | "intl" | "mbstring" | "opcache" | "pdo" | "phar" | "posix" | "readline" | "shmop" | "simplexml" | "sockets" | "sysvmsg" | "sysvsem" | "sysvshm" | "tokenizer" | "xml" | "xmlreader" | "xmlwriter" | "xsl" | "zip")

--- a/setup/ubuntu/dependencies
+++ b/setup/ubuntu/dependencies
@@ -1,0 +1,10 @@
+git
+jq
+libxml2-utils
+libzip-dev
+npm
+sudo
+wget
+yamllint
+zip
+msodbcsql17

--- a/setup/ubuntu/setup.sh
+++ b/setup/ubuntu/setup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 apt update \
     && apt install -y software-properties-common curl \
     && (curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -) \

--- a/setup/ubuntu/setup.sh
+++ b/setup/ubuntu/setup.sh
@@ -1,0 +1,6 @@
+apt update \
+    && apt install -y software-properties-common curl \
+    && (curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -) \
+    && add-apt-repository -y ppa:ondrej/php \
+    && add-apt-repository -y https://packages.microsoft.com/ubuntu/20.04/prod \
+    && ACCEPT_EULA=Y xargs -a dependencies apt install -y


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      |  no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This provides initial support for PHP 8.1.
This setup is very basic and currently only supports pre-compiled extensions by https://github.com/shivammathur/php-builder.
These extensions are:

```
amqp
apcu
bcmath
bz2
calendar
Core
ctype
curl
date
dom
enchant
exif
FFI
fileinfo
filter
ftp
gd
gettext
gmp
hash
iconv
igbinary
imagick
intl
json
ldap
libxml
mbstring
memcache
memcached
msgpack
mysqli
mysqlnd
openssl
pcntl
pcre
PDO
pdo_mysql
pdo_pgsql
pdo_sqlite
pgsql
Phar
posix
pspell
readline
redis
Reflection
session
shmop
SimpleXML
soap
sockets
sodium
SPL
sqlite3
standard
sysvmsg
sysvsem
sysvshm
tidy
tokenizer
xml
xmlreader
xmlwriter
xsl
zip
zlib
```

The `xdebug` extension is also available but disabled by default (the same way as in all other PHP versions).
`pcov` is also available and can be enabled.

If any project needs more than these extensions, they need to install these by themselves by using the `pre-run.sh` script which is being executed on each run.

----

This supersedes #46 