### PR TITLE
Enforce `convertDeprecationsToExceptions=true` in `phpunit` configuration if missing entirely

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -183,6 +183,7 @@ if [[ "${COMMAND}" =~ phpunit ]];then
     echo "Setting up PHPUnit problem matcher"
     cp /etc/laminas-ci/problem-matcher/phpunit.json "$(pwd)/phpunit.json"
     echo "::add-matcher::phpunit.json"
+    /scripts/phpunit-deprecations-to-exception.sh
 fi
 
 if [[ "${COMMAND}" =~ markdownlint ]];then

--- a/scripts/logging-functions.sh
+++ b/scripts/logging-functions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+function warning() {
+    MESSAGE="$*";
+    write "\e[33m$MESSAGE"
+}
+
+function error() {
+    MESSAGE="$*";
+    >&2 write "\e[31m$MESSAGE"
+}
+
+function log() {
+    MESSAGE="$*";
+    write "\e[39m$MESSAGE"
+}
+
+function write() {
+    MESSAGE="$*";
+    test -t 1 && echo -e "$MESSAGE\e[39m"
+}
+
+function info() {
+    MESSAGE="$*";
+    >&2 write "\e[32m$MESSAGE";
+}

--- a/scripts/phpunit-deprecations-to-exception.sh
+++ b/scripts/phpunit-deprecations-to-exception.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -f "/scripts/logging-functions.sh" ]; then
+  source /scripts/logging-functions.sh
+elif [ -f "scripts/logging-functions.sh" ]; then
+  source scripts/logging-functions.sh
+else
+  echo "Could not find logging-functions.sh"
+  exit 1
+fi
+
+PHPUNIT_CONFIGURATION_FILE=""
+
+if [ -f "phpunit.xml" ]; then
+    PHPUNIT_CONFIGURATION_FILE="phpunit.xml"
+elif [ -f "phpunit.xml.dist" ]; then
+  PHPUNIT_CONFIGURATION_FILE="phpunit.xml.dist"
+else
+  warning "Could not detect phpunit configuration. Won't change anything."
+  exit 0;
+fi
+
+if [ -z "${PHPUNIT_CONFIGURATION_FILE}" ]; then
+  error "Could not detect phpunit configuration. Please report this to https://github.com/laminas/laminas-continuous-integration-action/issues"
+  exit 1;
+fi
+
+warning "Updating ${PHPUNIT_CONFIGURATION_FILE} to enforce convertDeprecationsToExceptions=true."
+warning "In case that the project specifies that value itself, this won't update anything."
+
+xmlstarlet ed --inplace --insert '//phpunit[not(@convertDeprecationsToExceptions)]' \
+            --type attr --name 'convertDeprecationsToExceptions' --value "true" \
+            "${PHPUNIT_CONFIGURATION_FILE}"

--- a/setup/ubuntu/dependencies
+++ b/setup/ubuntu/dependencies
@@ -8,3 +8,4 @@ wget
 yamllint
 zip
 msodbcsql17
+xmlstarlet


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This will reset all CI runs behavior back to pre `phpunit` `9.5.10`/`8.5.21` where `convertDeprecationsToExceptions` default value was set from `true` to `false`.

