### PR TITLE
Install `phpdbg` and alias it to correct version in the `ENTRYPOINT` script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -137,6 +137,7 @@ echo "Marking PHP ${PHP} as configured default"
 update-alternatives --quiet --set php "/usr/bin/php${PHP}"
 update-alternatives --quiet --set php-config "/usr/bin/php-config${PHP}"
 update-alternatives --quiet --set phpize "/usr/bin/phpize${PHP}"
+update-alternatives --quiet --set phpdbg "/usr/bin/phpdbg${PHP}"
 
 checkout
 

--- a/setup/php/5.6/dependencies
+++ b/setup/php/5.6/dependencies
@@ -7,6 +7,7 @@ php5.6-intl
 php5.6-json
 php5.6-mbstring
 php5.6-phar
+php5.6-phpdbg
 php5.6-readline
 php5.6-sockets
 php5.6-xml

--- a/setup/php/7.0/dependencies
+++ b/setup/php/7.0/dependencies
@@ -7,6 +7,7 @@ php7.0-intl
 php7.0-json
 php7.0-mbstring
 php7.0-phar
+php7.0-phpdbg
 php7.0-readline
 php7.0-sockets
 php7.0-xml

--- a/setup/php/7.1/dependencies
+++ b/setup/php/7.1/dependencies
@@ -7,6 +7,7 @@ php7.1-intl
 php7.1-json
 php7.1-mbstring
 php7.1-phar
+php7.1-phpdbg
 php7.1-readline
 php7.1-sockets
 php7.1-xml

--- a/setup/php/7.2/dependencies
+++ b/setup/php/7.2/dependencies
@@ -7,6 +7,7 @@ php7.2-intl
 php7.2-json
 php7.2-mbstring
 php7.2-phar
+php7.2-phpdbg
 php7.2-readline
 php7.2-sockets
 php7.2-xml

--- a/setup/php/7.3/dependencies
+++ b/setup/php/7.3/dependencies
@@ -7,6 +7,7 @@ php7.3-intl
 php7.3-json
 php7.3-mbstring
 php7.3-phar
+php7.3-phpdbg
 php7.3-readline
 php7.3-sockets
 php7.3-xml

--- a/setup/php/7.4/dependencies
+++ b/setup/php/7.4/dependencies
@@ -7,6 +7,7 @@ php7.4-intl
 php7.4-json
 php7.4-mbstring
 php7.4-phar
+php7.4-phpdbg
 php7.4-readline
 php7.4-sockets
 php7.4-xml

--- a/setup/php/8.0/dependencies
+++ b/setup/php/8.0/dependencies
@@ -6,6 +6,7 @@ php8.0-fileinfo
 php8.0-intl
 php8.0-mbstring
 php8.0-phar
+php8.0-phpdbg
 php8.0-readline
 php8.0-sockets
 php8.0-xml


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This allows usage of the built-in PHP debugger, without the need to install larger
third-party extensions.

This is a requirement for https://github.com/laminas/laminas-ci-matrix-action/pull/70