### PR TITLE
Switch to Sury repo for PHP 8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN for INSTALLER in /mods-install/*.sh;do ${INSTALLER} ; done
 
 RUN mkdir -p /etc/laminas-ci/problem-matcher \
     && cd /etc/laminas-ci/problem-matcher \
-    && wget https://raw.githubusercontent.com/shivammathur/setup-php/master/src/configs/phpunit.json \
+    && wget https://raw.githubusercontent.com/shivammathur/setup-php/master/src/configs/pm/phpunit.json \
     && wget -O markdownlint.json https://raw.githubusercontent.com/xt0rted/markdownlint-problem-matcher/main/.github/problem-matcher.json
 
 COPY etc/markdownlint.json /etc/laminas-ci/markdownlint.json

--- a/setup/php/8.1/dependencies
+++ b/setup/php/8.1/dependencies
@@ -1,0 +1,14 @@
+php8.1-cli
+php8.1-bz2
+php8.1-curl
+php8.1-dev
+php8.1-fileinfo
+php8.1-intl
+php8.1-mbstring
+php8.1-phar
+php8.1-phpdbg
+php8.1-readline
+php8.1-sockets
+php8.1-xml
+php8.1-xsl
+php8.1-zip

--- a/setup/php/8.1/setup.sh
+++ b/setup/php/8.1/setup.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-curl -sSLO https://github.com/shivammathur/php-builder/releases/latest/download/install.sh
-chmod a+x ./install.sh
-./install.sh 8.1
-
-# Prepares the configuration the same way as mods-install/install_sqlsrv.sh would do
-cat /etc/php/8.1/mods-available/pdo_sqlsrv.ini >> /etc/php/8.1/mods-available/sqlsrv.ini
-rm /etc/php/8.1/mods-available/pdo_sqlsrv.ini
+ACCEPT_EULA=Y xargs -a dependencies apt install -y


### PR DESCRIPTION
With a stable 8.1, we can revert back to the sury repo to ensure consistency in the PHP build versions and ability to enable/disable extensions.

Infrastructure remains so that we can switch to the PHP Builder again later, should we choose to do so.
