### PR TITLE
Use pre-build Swoole/OpenSwoole extensions

### DIFF
--- a/mods-available/swoole.ini
+++ b/mods-available/swoole.ini
@@ -1,3 +1,0 @@
-; configuration for php swoole module
-; priority=20
-extension=swoole.so

--- a/mods-install/install_swoole.sh
+++ b/mods-install/install_swoole.sh
@@ -2,27 +2,14 @@
 
 set -e
 
-SWOOLE_VERSION=4.7.0
+SWOOLE_PACKAGE_URL=https://uploads.mwop.net/laminas-ci/swoole-4.8.2-openswoole-4.8.0.tgz
+SWOOLE_PACKAGE=$(basename "${SWOOLE_PACKAGE_URL}")
 
-# Get swoole package ONCE
+# Download the pre-built extensions
 cd /tmp
-wget https://pecl.php.net/get/swoole-${SWOOLE_VERSION}.tgz
-tar xzf swoole-${SWOOLE_VERSION}.tgz
-
-# We only need to support currently supported PHP versions
-for PHP_VERSION in 7.3 7.4 8.0;do
-    cd /tmp/swoole-${SWOOLE_VERSION}
-    if [ -f Makefile ];then
-        make clean
-    fi
-    phpize${PHP_VERSION}
-    ./configure --enable-swoole --enable-sockets --with-php-config=php-config${PHP_VERSION}
-    make
-    make install
-
-    cp /mods-available/swoole.ini /etc/php/${PHP_VERSION}/mods-available/swoole.ini
-done
+wget "${SWOOLE_PACKAGE_URL}"
+cd /
+tar xzf "/tmp/${SWOOLE_PACKAGE}"
 
 # Cleanup
-rm -rf /tmp/swoole-${SWOOLE_VERSION}
-rm /tmp/swoole-${SWOOLE_VERSION}.tgz
+rm -rf "/tmp/${SWOOLE_PACKAGE}"


### PR DESCRIPTION
Instead of building Swoole each time we change the container, we can pre-build it once and pull it in, similar to how we consume the sqlsrv extension. I've created a project, [laminas-ci-swoole-builder](https://github.com/weierophinney/laminas-ci-swoole-builder) that builds both Swoole and OpenSwoole using containers mimicing the Laminas-CI setup. The artifacts are then packaged and uploaded to an S3 bucket, allowing us to pull them in here. This can eventually be managed directly by Laminas, but in the meantime, should speed up our container builds, and give us quicker turnaround on new Swoole and OpenSwoole versions.

The tarball contains `/etc` and `/usr` subtrees that include:

- mods-available INI files for each extension for each PHP version
- headers for each extension version
- the built binary extension for each extension version

This patch also:

- Updates the Swoole version to 4.8.2, for each of PHP 7.3, 7.4, 8.0, and 8.1.
- Adds OpenSwoole extensions version 4.8.0 for each of PHP 7.3, 7.4, 8.0, and 8.1.
