### PR TITLE
Allow installing extensions on PHP 8.1 normally

### DIFF
--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -14,12 +14,13 @@ function install_extensions {
     done
 
     case "$PHP" in
-        8.1)
-            echo "Cannot install extensions for the current PHP version."
-            echo "Please use \".laminas-ci/pre-run.sh\" to setup specific extensions for PHP $PHP"
-            echo "Additional details can be found on https://stackoverflow.com/q/8141407"
-            echo "The following extensions were not installed: ${EXTENSIONS[*]}"
-        ;;
+		# Example for handling extensions for different PHP versions:
+        # 8.1)
+        #     echo "Cannot install extensions for the current PHP version."
+        #     echo "Please use \".laminas-ci/pre-run.sh\" to setup specific extensions for PHP $PHP"
+        #     echo "Additional details can be found on https://stackoverflow.com/q/8141407"
+        #     echo "The following extensions were not installed: ${EXTENSIONS[*]}"
+        # ;;
         *)
             install_packaged_extensions "$PHP" "${EXTENSIONS[@]}"
         ;;


### PR DESCRIPTION
When releasing 1.14.0, I missed that the extensions script had a special case for 8.1, and discovered it later (https://github.com/mezzio/mezzio-authentication/runs/4397696325?check_suite_focus=true#step:3:17).

This patch removes that case by commenting it out, but leaves the comment as an example of how to vary behavior based on PHP version.
