### PR TITLE
Ensure apt runs in noninteractive mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL "homepage"="http://github.com/laminas/laminas-continuous-integration-actio
 LABEL "maintainer"="https://github.com/laminas/technical-steering-committee/"
 
 ENV COMPOSER_HOME=/usr/local/share/composer
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY setup /setup
 # Base setup


### PR DESCRIPTION
Setting DEBIAN_FRONTEND=noninteractive as a container-level ENV variable, so all apt operations occur in noninteractive shells.

Should resolve issues as seen with laminas/laminas-barcode#15
