### PR TITLE
When installing PHP INI settings from STDIN, configure also the PHPDBG SAPI

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,6 +171,7 @@ fi
 if [[ "${INI}" != "" ]];then
     echo "Installing php.ini settings"
     echo "$INI" > "/etc/php/${PHP}/cli/conf.d/99-settings.ini"
+    echo "$INI" > "/etc/php/${PHP}/phpdbg/conf.d/99-settings.ini"
 fi
 
 echo "PHP version: $(php --version)"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

PHPDBG, being its own independent SAPI, has its settings in `/etc/php/${VERSION}/phpdbg`,
rather than in `/etc/php/${VERSION}/cli`.

This change adjusts our `entrypoint.sh` to write INI settings also to that location,
preventing silly issues like memory limits being too low (our defaults set `memory_limit=-1`).

Fixes https://github.com/laminas/laminas-ci-matrix-action/issues/72
