### PR TITLE
Use strict composer version to help dependabot do his job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+    -   package-ecosystem: "docker"
+        directory: "/"
+        schedule:
+          interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM composer:2 AS composer
-
 FROM ubuntu:focal
 
 LABEL "repository"="http://github.com/laminas/laminas-continuous-integration-action"
@@ -47,7 +45,7 @@ RUN mkdir -p /etc/laminas-ci/problem-matcher \
 
 COPY etc/markdownlint.json /etc/laminas-ci/markdownlint.json
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.2.4 /usr/bin/composer /usr/bin/composer
 
 RUN mkdir -p /usr/local/share/composer \
     && composer global require staabm/annotate-pull-request-from-checkstyle \


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Use strict composer version to help @dependabot suggest updates. Suggested by @Ocramius https://github.com/mezzio/mezzio-tooling/pull/20#issuecomment-1004754902 . Resolves https://github.com/mezzio/mezzio-tooling/pull/20
