### PR TITLE
Restore previous tagging behavior for container workflow

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -34,6 +34,8 @@ jobs:
           images: ghcr.io/laminas/laminas-continuous-integration
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=ref,event=branch
             type=ref,event=pr
           flavor: |


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
I missed in #76 that previous workflow would tag `major`, `major.minor` and `major.minor.patch` for the release. Restoring that behavior.

I should point out that tagging like this is somewhat naive and latest build will take over the more generic tag. Eg `1.18.0` followed by `1.17.1` would end up in `@1` pointing to `1.17.1` instead of latest `1.18.0`
It is not really a concern with the way we tag releases in this package.
