### PR TITLE
Disable `platform.php` composer config for lowest/latest jobs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,14 +88,19 @@ function composer_install_dependencies {
         COMPOSER_ARGS="${COMPOSER_ARGS} --ignore-platform-req=php"
     fi
 
+
     case $DEPS in
         lowest)
             echo "Installing lowest supported dependencies via Composer"
+            # Disable platform.php, if set
+            composer config --unset platform.php
             # shellcheck disable=SC2086
             composer update ${COMPOSER_ARGS} --prefer-lowest
             ;;
         latest)
             echo "Installing latest supported dependencies via Composer"
+            # Disable platform.php, if set
+            composer config --unset platform.php
             # shellcheck disable=SC2086
             composer update ${COMPOSER_ARGS}
             ;;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | maybe?
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

Per the February 2022 TSC meeting, when doing `composer update` operations, we should honor the current PHP version, and not the one listed in the platform.php configuration.

Renovate-Bot needs a platform.php setting to use when updating `composer.lock` to ensure that it updates to dependencies supported by our minimum supported PHP version.
However, when running CI, if such a setting is present, we'll never test against dependency versions supported by later PHP versions, and hence it needs to be removed when testing against latest and lowest dependencies.
