### PR TITLE
Update sqlsrv extension to 5.10 and add PHP 8.1 support

### DIFF
--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -5,9 +5,10 @@ set -e
 cd tmp
 
 # Download extension versions from MS
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.4.tar | tar xf - --strip-components=1 Ubuntu2004-7.4/php_pdo_sqlsrv_74_nts.so Ubuntu2004-7.4/php_sqlsrv_74_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-7.4.tar | tar xf - --strip-components=1 Ubuntu2004-7.4/php_pdo_sqlsrv_74_nts.so Ubuntu2004-7.4/php_sqlsrv_74_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-8.1.tar | tar xf - --strip-components=1 Ubuntu2004-8.1/php_pdo_sqlsrv_81_nts.so Ubuntu2004-8.1/php_sqlsrv_81_nts.so
 
 # Copy extensions to appropriate locations for each PHP version
 mv php_pdo_sqlsrv_73_nts.so "$(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
@@ -16,8 +17,10 @@ mv php_pdo_sqlsrv_74_nts.so "$(php7.4 -i | grep -P '^extension_dir' | sed -E -e 
 mv php_sqlsrv_74_nts.so "$(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
 mv php_pdo_sqlsrv_80_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
 mv php_sqlsrv_80_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
+mv php_pdo_sqlsrv_81_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
+mv php_sqlsrv_81_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
 
 # Copy conf file to appropriate locations
-for PHP_VERSION in 7.3 7.4 8.0;do
+for PHP_VERSION in 7.3 7.4 8.0 8.1;do
     cp /mods-available/sqlsrv.ini "/etc/php/${PHP_VERSION}/mods-available/sqlsrv.ini"
 done

--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -17,8 +17,8 @@ mv php_pdo_sqlsrv_74_nts.so "$(php7.4 -i | grep -P '^extension_dir' | sed -E -e 
 mv php_sqlsrv_74_nts.so "$(php7.4 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
 mv php_pdo_sqlsrv_80_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
 mv php_sqlsrv_80_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
-mv php_pdo_sqlsrv_81_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
-mv php_sqlsrv_81_nts.so "$(php8.0 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
+mv php_pdo_sqlsrv_81_nts.so "$(php8.1 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
+mv php_sqlsrv_81_nts.so "$(php8.1 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
 
 # Copy conf file to appropriate locations
 for PHP_VERSION in 7.3 7.4 8.0 8.1;do


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

Version 5.10.0 of the sqlsrv extension adds support for PHP 8.1.

Will allow laminas/laminas-db#239 to test against PHP 8.1.
