### PR TITLE
Fix sqlsrv installation and enablement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,7 +210,7 @@ RUN apt update \
 # Build/install static modules that do not have packages
 COPY mods-available /mods-available
 COPY mods-install /mods-install
-RUN for INSTALLER in /mods-install/*.sh;do ${INSTALLER} ; done
+RUN set -e; for INSTALLER in /mods-install/*.sh; do ${INSTALLER} ; done
 
 COPY scripts /scripts
 RUN chmod a+x /scripts/*

--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -5,7 +5,7 @@ set -e
 cd tmp
 
 # Download extension versions from MS
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-7.4.tar | tar xf - --strip-components=1 Ubuntu2004-7.4/php_pdo_sqlsrv_74_nts.so Ubuntu2004-7.4/php_sqlsrv_74_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.0/Ubuntu2004-8.1.tar | tar xf - --strip-components=1 Ubuntu2004-8.1/php_pdo_sqlsrv_81_nts.so Ubuntu2004-8.1/php_sqlsrv_81_nts.so


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

The 5.10.0 release does NOT include support for PHP 7.3, which caused the install_sqlsrv.sh to fail. However, because we did not have a `set -e` directive associated with the `RUN` declaration that invokes the script, the container built without errors.

This patch does two things:

- Switches to the 5.9.0 release for installing the sqlsrv extension for PHP 7.3.
- Adds a `set -e` directive to the `RUN` line that installs static extensions.
