### PR TITLE
Updated location for the Swoole/OpenSwoole extension package

### DIFF
--- a/mods-install/install_swoole.sh
+++ b/mods-install/install_swoole.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-SWOOLE_PACKAGE_URL=https://uploads.mwop.net/laminas-ci/swoole-4.8.2-openswoole-4.8.0.tgz
+SWOOLE_PACKAGE_URL=https://github.com/weierophinney/laminas-ci-swoole-builder/releases/download/0.1.0/swoole-4.8.2-openswoole-4.8.0.tgz
 SWOOLE_PACKAGE=$(basename "${SWOOLE_PACKAGE_URL}")
 
 # Download the pre-built extensions


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

I had to move these from a private server to a GitHub release asset to prevent further bandwidth charges.
