### PR TITLE
Fix: disable `git`'s `safe.directory` handling completely

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,7 @@ RUN apt update \
     && apt autoremove -y \
     && apt clean
 
+RUN git config --global --add safe.directory '*'
 
 # Build/install static modules that do not have packages
 COPY mods-available /mods-available


### PR DESCRIPTION
Starting with GIT 2.35.3, GIT disallows operating on directories owned by other users.

This is to prevent hooks from taking over the system, but this container is a single-user
environment, and hooks are generally not configured on checkout anyway.

This container has a different $UID/$GID than the parent worker, which performs `git clone`.

With this `git config` change, we ignore this security scenario completely.

Ref: https://stackoverflow.com/questions/71849415/i-cannot-add-the-parent-directory-to-safe-directory-in-git/71904131#71904131

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
