### PR TITLE
Fix: disable `git`'s `safe.directory` handling completely (for `testuser`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,8 +206,6 @@ RUN apt update \
     && apt autoremove -y \
     && apt clean
 
-RUN git config --global --add safe.directory '*'
-
 # Build/install static modules that do not have packages
 COPY mods-available /mods-available
 COPY mods-install /mods-install
@@ -244,6 +242,7 @@ COPY setup/markdownlint/problem-matcher.json /etc/laminas-ci/problem-matcher/mar
 COPY setup/phpunit/problem-matcher.json /etc/laminas-ci/problem-matcher/phpunit.json
 
 
-RUN useradd -ms /bin/bash testuser
+RUN useradd -ms /bin/bash testuser \
+    && sudo -u testuser git config --global --add safe.directory '*'
 
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
This commit repeats 42ae46d49c2b5d5432a362309e1393536679121d ( https://github.com/laminas/laminas-continuous-integration-action/pull/95 ),
but this time accounts for the fact that we run our CI operations with the `testuser`
account.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
