### PR TITLE
Git `safe-directory` fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,7 +242,6 @@ COPY setup/markdownlint/problem-matcher.json /etc/laminas-ci/problem-matcher/mar
 COPY setup/phpunit/problem-matcher.json /etc/laminas-ci/problem-matcher/phpunit.json
 
 
-RUN useradd -ms /bin/bash testuser \
-    && sudo -u testuser git config --global --add safe.directory '*'
+RUN useradd -ms /bin/bash testuser
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -144,6 +144,8 @@ update-alternatives --quiet --set php-config "/usr/bin/php-config${PHP}"
 update-alternatives --quiet --set phpize "/usr/bin/phpize${PHP}"
 update-alternatives --quiet --set phpdbg "/usr/bin/phpdbg${PHP}"
 
+# Marks the working directory as safe for the current user prior to checkout
+git config --global --add safe.directory '*'
 checkout
 
 # Is there a pre-install script available?


### PR DESCRIPTION
Moves git config call for safe.directory from the Dockerfile to the entrypoint

Ref #97 