### PR TITLE
Introduce `before_script` which will be executed prior the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ The JSON string should represent an object with the following information:
   "command": "command to run to perform the check (empty in case you dont want to excecute any command)",
   "additional_composer_arguments": [
     "arguments which will be passed to `composer install` or `composer update`, passed as a list or as a list; e.g. --no-scripts"
+  ],
+  "gatekeeper_commands": [
+    "tool configuration linting",
+    "tool specific setting overrides",
+    "specific composer dependency to be installed prior executing command"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The `.laminas-ci/pre-run.sh` command runs immediately prior to the QA command, a
 - `$2`: the WORKDIR path
 - `$3`: the `$JOB` passed to the entrypoint (see above)
 
+It is also possible to pass `before_script` with a list of commands via the `$JOB` variable.
+
 The `.laminas-ci/post-run.sh` command will receive these arguments:
 
 - `$1`: the exit status of the QA command

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The JSON string should represent an object with the following information:
   "additional_composer_arguments": [
     "arguments which will be passed to `composer install` or `composer update`, passed as a list or as a list; e.g. --no-scripts"
   ],
-  "gatekeeper_commands": [
+  "before_script": [
     "tool configuration linting",
     "tool specific setting overrides",
     "specific composer dependency to be installed prior executing command"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The container the action provides and consumes builds off the ubuntu:focal image
 - 7.3
 - 7.4
 - 8.0
+- 8.1
 
 Each provides the following extensions by default:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ function help {
     echo " - dependencies:                    the dependency set to run against (lowest, latest, locked)"
     echo " - ignore_php_platform_requirement: flag to enable/disable the PHP platform requirement when executing composer \`install\` or \`update\`"
     echo " - additional_composer_arguments:   a list of composer arguments to be added when \`install\` or \`update\` is called."
-    echo " - gatekeeper_commands:             a list of commands to run prior the real command"
+    echo " - before_script:                   a list of commands to run before the real command"
     echo ""
 }
 
@@ -140,8 +140,8 @@ if [[ "${PHP}" == "" ]];then
     exit 1
 fi
 
-declare -a GATEKEEPER_COMMANDS=()
-readarray -t GATEKEEPER_COMMANDS="$(echo "${JOB}" | jq -rc '(.gatekeeper_commands // [])[]' )"
+declare -a BEFORE_SCRIPT=()
+readarray -t BEFORE_SCRIPT="$(echo "${JOB}" | jq -rc '(.before_script // [])[]' )"
 
 echo "Marking PHP ${PHP} as configured default"
 update-alternatives --quiet --set php "/usr/bin/php${PHP}"
@@ -221,9 +221,9 @@ if [ -x ".laminas-ci/pre-run.sh" ];then
     ./.laminas-ci/pre-run.sh testuser "${PWD}" "${JOB}"
 fi
 
-# Execute gatekeeper commands before executing the CI command
-for GATEKEEPER_COMMAND in "${GATEKEEPER_COMMANDS[@]}"; do
-  sudo --preserve-env --set-home -u testuser /bin/bash -c "${GATEKEEPER_COMMAND}"
+for BEFORE_SCRIPT_COMMAND in "${BEFORE_SCRIPT[@]}"; do
+  echo "Running before_script: ${BEFORE_SCRIPT_COMMAND}"
+  sudo --preserve-env --set-home -u testuser /bin/bash -c "${BEFORE_SCRIPT_COMMAND}"
 done
 
 # Disable exit-on-non-zero flag so we can run post-commands


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This adds the possibility to pass gatekeeping commands to the action without actually polluting the real command.

- with https://github.com/laminas/laminas-ci-matrix-action/pull/31, we want to introduce linting of phpunit, psalm, etc. configuration files
- in https://github.com/laminas/laminas-cache/pull/196/files#diff-3fb49ad00d3736f1ca8276f568f5d8bbe8c1604f6187ab5ecf921e1012f47c98R15, we want to install a very specific version of a composer dependency which won't be installed when using `lowest` or `latest` (due to the constraint `^1.0 || ^2.0 || ^3.0`)
- I've added some `xmlstarlet` magic to modify `convertDeprecationsToExceptions` setting within `phpunit.xml.dist` in https://github.com/laminas/laminas-component-installer/blob/3c998d2b2755985c71cd4d5d9b294228f63d3a65/.laminas-ci.json#L6

All these quirks could be passed via that new JOB property instead of passing consecutive commands via the `command` property.

----

I am open to rename the property, I simply did not found a better naming (yet).

