### PR TITLE
Fix #116: ensure `.ini` settings are reset for both `phpdbg` and `php-cli` SAPIs

### DIFF
--- a/scripts/php_ini_dev_settings.sh
+++ b/scripts/php_ini_dev_settings.sh
@@ -4,6 +4,7 @@ set -e
 
 declare -a SUBSTITUTIONS
 
+SUBSTITUTIONS+=('s/memory_limit ?= ?(.*)/memory_limit = -1/')
 SUBSTITUTIONS+=('s/zend.exception_ignore_args ?= ?(On|Off)/zend.exception_ignore_args = Off/')
 SUBSTITUTIONS+=('s/zend.exception_string_param_max_len ?= ?[0-9]+/zend.exception_string_param_max_len = 15/')
 SUBSTITUTIONS+=('s/error_reporting ?= ?[A-Z_~ &]+/error_reporting = E_ALL/')
@@ -14,8 +15,10 @@ SUBSTITUTIONS+=('s/zend.assertions ?= ?(-1|1)/zend.assertions = 1/')
 SUBSTITUTIONS+=('s/opcache.huge_code_pages ?= ?(0|1)/opcache.huge_code_pages = 0/')
 
 for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1;do
-    INI_FILE="/etc/php/${PHP_VERSION}/cli/php.ini"
-    for SUBSTITUTION in "${SUBSTITUTIONS[@]}";do
-        sed --in-place -E -e "${SUBSTITUTION}" "${INI_FILE}"
+    for PHP_SAPI in cli phpdbg; do
+        INI_FILE="/etc/php/${PHP_VERSION}/${PHP_SAPI}/php.ini"
+        for SUBSTITUTION in "${SUBSTITUTIONS[@]}";do
+            sed --in-place -E -e "${SUBSTITUTION}" "${INI_FILE}"
+        done
     done
 done


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #116

This is caused by `phpdbg` and `php-cli` using different configuration paths, in the ubuntu-distributed PHP `.deb` setup.

I targeted `1.22.0`, since this doesn't really need backporting. 