### PR TITLE
Ensure `BEFORE_SCRIPT` and `AFTER_SCRIPT` are populated correctly 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,14 +142,10 @@ if [[ "${PHP}" == "" ]];then
 fi
 
 declare -a BEFORE_SCRIPT=()
-while IFS='' read -r line; do
-    BEFORE_SCRIPT+=("$line")
-done < <(echo "${JOB}" | jq -rc '(.before_script // [])[]')
+readarray -t BEFORE_SCRIPT < <(echo "${JOB}" | jq -rc '(.before_script // [])[]' )
 
 declare -a AFTER_SCRIPT=()
-while IFS='' read -r line; do
-    AFTER_SCRIPT+=("$line")
-done < <(echo "${JOB}" | jq -rc '(.after_script // [])[]')
+readarray -t AFTER_SCRIPT < <(echo "${JOB}" | jq -rc '(.after_script // [])[]' )
 
 
 echo "Marking PHP ${PHP} as configured default"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,16 +142,14 @@ if [[ "${PHP}" == "" ]];then
 fi
 
 declare -a BEFORE_SCRIPT=()
-BEFORE_SCRIPT_STRING="$(echo "${JOB}" | jq -rc '(.before_script // [])[]' | tr -d '\n')"
-if [[ "${BEFORE_SCRIPT_STRING}" != "" ]]; then
-    readarray -t BEFORE_SCRIPT="${BEFORE_SCRIPT_STRING}"
-fi
+while IFS='' read -r line; do
+    BEFORE_SCRIPT+=("$line")
+done < <(echo "${JOB}" | jq -rc '(.before_script // [])[]')
 
 declare -a AFTER_SCRIPT=()
-AFTER_SCRIPT_STRING="$(echo "${JOB}" | jq -rc '(.after_script // [])[]' | tr -d '\n')"
-if [[ "${AFTER_SCRIPT_STRING}" != "" ]]; then
-    readarray -t AFTER_SCRIPT="${AFTER_SCRIPT_STRING}"
-fi
+while IFS='' read -r line; do
+    AFTER_SCRIPT+=("$line")
+done < <(echo "${JOB}" | jq -rc '(.after_script // [])[]')
 
 
 echo "Marking PHP ${PHP} as configured default"


### PR DESCRIPTION
After discussions with @ghostwriter, and after some simple testing on this myself to confirm, this is the proposed fix to prevent the error:
```
/usr/local/bin/entrypoint.sh: line 147: readarray: `BEFORE_SCRIPT=xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist': not a valid identifier
```

Note: I'm not able to use git CLI right now, but consider this signed off.