### PR TITLE
Adding `make` to CI container as per #135

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN apt update \
         jq \
         libxml2-utils \
         libzip-dev \
+        make \
         nodejs \
         sudo \
         wget \


### PR DESCRIPTION
The `make` command was missing: it is used by some `pecl` commands, as well as some build commands internal to php-src.

Fixes #135
