### PR TITLE
Update base URL for Open/Swoole packages

### DIFF
--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-SWOOLE_PACKAGE_URL="https://github.com/weierophinney/laminas-ci-swoole-builder/releases/download/0.2.0/php%s-%s.tgz"
+SWOOLE_PACKAGE_URL="https://github.com/weierophinney/laminas-ci-swoole-builder/releases/download/0.2.2/php%s-%s.tgz"
 
 function install_extensions {
     local PHP=$1


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

New release of weierophinney/laminas-ci-swoole-builder (0.2.2) has support for PHP 8.2 builds.
