### PR TITLE
Set the default stable PHP version to 8.0, Apply default ini settings to PHP 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,9 +219,9 @@ RUN apt update \
         php8.2-xsl \
         php8.2-zip \
     # Set default PHP version
-    && update-alternatives --set php /usr/bin/php7.4 \
-    && update-alternatives --set phpize /usr/bin/phpize7.4 \
-    && update-alternatives --set php-config /usr/bin/php-config7.4 \
+    && update-alternatives --set php /usr/bin/php8.0 \
+    && update-alternatives --set phpize /usr/bin/phpize8.0 \
+    && update-alternatives --set php-config /usr/bin/php-config8.0 \
     && apt autoremove -y \
     && apt clean
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The container the action provides and consumes builds off the ubuntu:focal image
 - 7.4
 - 8.0
 - 8.1
+- 8.2
 
 Each provides the following extensions by default:
 

--- a/scripts/php_ini_dev_settings.sh
+++ b/scripts/php_ini_dev_settings.sh
@@ -14,7 +14,7 @@ SUBSTITUTIONS+=('s/mysqlnd.collect_memory_statistics ?= ?(On|Off)/mysqlnd.collec
 SUBSTITUTIONS+=('s/zend.assertions ?= ?(-1|1)/zend.assertions = 1/')
 SUBSTITUTIONS+=('s/opcache.huge_code_pages ?= ?(0|1)/opcache.huge_code_pages = 0/')
 
-for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1;do
+for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2;do
     for PHP_SAPI in cli phpdbg; do
         INI_FILE="/etc/php/${PHP_VERSION}/${PHP_SAPI}/php.ini"
         for SUBSTITUTION in "${SUBSTITUTIONS[@]}";do


### PR DESCRIPTION
### Description

Updates default stable to 8.0

Also noticed that 8.2 was omitted from the version list for the application of default ini settings such as turning on assertions etc.

Adds 8.2 to the list of supported versions in the README

Closes #137, Closes #136