### PR TITLE
Raise open files limit back to ubuntu v20 values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -263,4 +263,8 @@ COPY setup/phpunit/problem-matcher.json /etc/laminas-ci/problem-matcher/phpunit.
 
 RUN useradd -ms /bin/bash testuser
 
+# Copy ubuntu setup
+COPY setup/ubuntu /
+RUN test 1048576 -eq $(sudo --preserve-env --set-home -u testuser /bin/bash -c ulimit -n) || (echo "Maximum open file limit is not configured properly" && exit 255)
+
 ENTRYPOINT ["entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -265,6 +265,5 @@ RUN useradd -ms /bin/bash testuser
 
 # Copy ubuntu setup
 COPY setup/ubuntu /
-RUN test 1048576 -eq $(sudo --preserve-env --set-home -u testuser /bin/bash -c ulimit -n) || (echo "Maximum open file limit is not configured properly" && exit 255)
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/setup/ubuntu/etc/security/limits.d/testuser.conf
+++ b/setup/ubuntu/etc/security/limits.d/testuser.conf
@@ -1,0 +1,2 @@
+testuser soft nofile 1048576
+testuser hard nofile 1048576


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With the introduction of Ubuntu v22, the maximum number of open file descriptors were lowered for non-root users from `1048576` to `1024`.

This will restore the old value of `1048576` which might fix some broken CI runs in the `laminas-cache-storage-adapter-*` repositories, etc.