### PR TITLE
Removed `phpdbg`, added `pcov` dependency as part of the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ RUN apt update \
         php5.6-intl \
         php5.6-json \
         php5.6-mbstring \
+        php5.6-pcov \
         php5.6-phar \
-        php5.6-phpdbg \
         php5.6-readline \
         php5.6-sockets \
         php5.6-xml \
@@ -102,8 +102,8 @@ RUN apt update \
         php7.0-intl \
         php7.0-json \
         php7.0-mbstring \
+        php7.0-pcov \
         php7.0-phar \
-        php7.0-phpdbg \
         php7.0-readline \
         php7.0-sockets \
         php7.0-xml \
@@ -118,8 +118,8 @@ RUN apt update \
         php7.1-intl \
         php7.1-json \
         php7.1-mbstring \
+        php7.1-pcov \
         php7.1-phar \
-        php7.1-phpdbg \
         php7.1-readline \
         php7.1-sockets \
         php7.1-xml \
@@ -134,8 +134,8 @@ RUN apt update \
         php7.2-intl \
         php7.2-json \
         php7.2-mbstring \
+        php7.2-pcov \
         php7.2-phar \
-        php7.2-phpdbg \
         php7.2-readline \
         php7.2-sockets \
         php7.2-xml \
@@ -150,8 +150,8 @@ RUN apt update \
         php7.3-intl \
         php7.3-json \
         php7.3-mbstring \
+        php7.3-pcov \
         php7.3-phar \
-        php7.3-phpdbg \
         php7.3-readline \
         php7.3-sockets \
         php7.3-xml \
@@ -166,8 +166,8 @@ RUN apt update \
         php7.4-intl \
         php7.4-json \
         php7.4-mbstring \
+        php7.4-pcov \
         php7.4-phar \
-        php7.4-phpdbg \
         php7.4-readline \
         php7.4-sockets \
         php7.4-xml \
@@ -181,8 +181,8 @@ RUN apt update \
         php8.0-fileinfo \
         php8.0-intl \
         php8.0-mbstring \
+        php8.0-pcov \
         php8.0-phar \
-        php8.0-phpdbg \
         php8.0-readline \
         php8.0-sockets \
         php8.0-xml \
@@ -196,8 +196,8 @@ RUN apt update \
         php8.1-fileinfo \
         php8.1-intl \
         php8.1-mbstring \
+        php8.1-pcov \
         php8.1-phar \
-        php8.1-phpdbg \
         php8.1-readline \
         php8.1-sockets \
         php8.1-xml \
@@ -211,8 +211,8 @@ RUN apt update \
         php8.2-fileinfo \
         php8.2-intl \
         php8.2-mbstring \
+        php8.2-pcov \
         php8.2-phar \
-        php8.2-phpdbg \
         php8.2-readline \
         php8.2-sockets \
         php8.2-xml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ RUN apt update \
         php5.6-intl \
         php5.6-json \
         php5.6-mbstring \
-        php5.6-pcov \
         php5.6-phar \
+        php5.6-phpdbg \
         php5.6-readline \
         php5.6-sockets \
         php5.6-xml \
@@ -102,8 +102,8 @@ RUN apt update \
         php7.0-intl \
         php7.0-json \
         php7.0-mbstring \
-        php7.0-pcov \
         php7.0-phar \
+        php7.0-phpdbg \
         php7.0-readline \
         php7.0-sockets \
         php7.0-xml \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -152,7 +152,6 @@ echo "Marking PHP ${PHP} as configured default"
 update-alternatives --quiet --set php "/usr/bin/php${PHP}"
 update-alternatives --quiet --set php-config "/usr/bin/php-config${PHP}"
 update-alternatives --quiet --set phpize "/usr/bin/phpize${PHP}"
-update-alternatives --quiet --set phpdbg "/usr/bin/phpdbg${PHP}"
 
 # Marks the working directory as safe for the current user prior to checkout
 git config --global --add safe.directory '*'
@@ -188,7 +187,6 @@ fi
 if [[ "${INI}" != "" ]];then
     echo "Installing php.ini settings"
     echo "$INI" > "/etc/php/${PHP}/cli/conf.d/99-settings.ini"
-    echo "$INI" > "/etc/php/${PHP}/phpdbg/conf.d/99-settings.ini"
 fi
 
 echo "PHP version: $(php --version)"

--- a/scripts/php_ini_dev_settings.sh
+++ b/scripts/php_ini_dev_settings.sh
@@ -15,10 +15,8 @@ SUBSTITUTIONS+=('s/zend.assertions ?= ?(-1|1)/zend.assertions = 1/')
 SUBSTITUTIONS+=('s/opcache.huge_code_pages ?= ?(0|1)/opcache.huge_code_pages = 0/')
 
 for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2;do
-    for PHP_SAPI in cli phpdbg; do
-        INI_FILE="/etc/php/${PHP_VERSION}/${PHP_SAPI}/php.ini"
-        for SUBSTITUTION in "${SUBSTITUTIONS[@]}";do
-            sed --in-place -E -e "${SUBSTITUTION}" "${INI_FILE}"
-        done
+    INI_FILE="/etc/php/${PHP_VERSION}/cli/php.ini"
+    for SUBSTITUTION in "${SUBSTITUTIONS[@]}";do
+        sed --in-place -E -e "${SUBSTITUTION}" "${INI_FILE}"
     done
 done


### PR DESCRIPTION
This is a potential breaking change, but note that PHPUnit v10 no longer supports PHPDBG for coverage, which was the only use-case for PHPDBG in this container, thus far.

We instead install `pcov`, which is considered precise enough for coverage reports by PHPUnit.

Fixes #130

Ref: https://github.com/laminas/laminas-continuous-integration-action/issues/130
Ref: https://github.com/sebastianbergmann/php-code-coverage/issues/945
Ref: https://github.com/sebastianbergmann/php-code-coverage/commit/c304be7d8aa00a71cf8fe763a4b92e14d3f67f4d

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes (?)
| New Feature   | yes
| RFC           | no
| QA            | yes

Only question here is:

 * do we release on `1.33.0`?
 * do we release on `2.0.0`?