### PR TITLE
Remove temporary fix for pre PHP 8.3 RC3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,14 +228,6 @@ RUN export OS_VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d '"' -f2) 
     && apt autoremove -y \
     && apt clean
 
-# Temporary fix for https://github.com/laminas/laminas-continuous-integration-action/issues/188
-RUN cp \
-    /usr/share/libtool/build-aux/config.sub \
-    /usr/share/libtool/build-aux/config.guess \
-    /usr/share/libtool/build-aux/ltmain.sh \
-    /usr/bin/shtool \
-    /usr/lib/php/20230831/build
-
 # Build/install static modules that do not have packages
 COPY mods-available /mods-available
 COPY mods-install /mods-install


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This removes a temporary fix introduced in v1.35.1 to have required files in place for PECL. With PHP 8.3, this got fixed by sury and thus there is no need for this anymore.
