### PR TITLE
Add PHP 8.3 support for sqlsrv extension

### DIFF
--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -10,6 +10,7 @@ curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.1/Ubuntu20
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.0/Ubuntu2004-8.1.tar | tar xf - --strip-components=1 Ubuntu2004-8.1/php_pdo_sqlsrv_81_nts.so Ubuntu2004-8.1/php_sqlsrv_81_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.0/Ubuntu2004-8.2.tar | tar xf - --strip-components=1 Ubuntu2004-8.2/php_pdo_sqlsrv_82_nts.so Ubuntu2004-8.2/php_sqlsrv_82_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.12.0-beta1/Ubuntu2004-8.3.tar | tar xf - --strip-components=1 Ubuntu2004-8.3/php_pdo_sqlsrv_83_nts.so Ubuntu2004-8.3/php_sqlsrv_83_nts.so
 
 # Copy extensions to appropriate locations for each PHP version
 mv php_pdo_sqlsrv_73_nts.so "$(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
@@ -22,8 +23,10 @@ mv php_pdo_sqlsrv_81_nts.so "$(php8.1 -i | grep -P '^extension_dir' | sed -E -e 
 mv php_sqlsrv_81_nts.so "$(php8.1 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
 mv php_pdo_sqlsrv_82_nts.so "$(php8.2 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
 mv php_sqlsrv_82_nts.so "$(php8.2 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
+mv php_pdo_sqlsrv_83_nts.so "$(php8.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"
+mv php_sqlsrv_83_nts.so "$(php8.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/sqlsrv.so"
 
 # Copy conf file to appropriate locations
-for PHP_VERSION in 7.3 7.4 8.0 8.1 8.2;do
+for PHP_VERSION in 7.3 7.4 8.0 8.1 8.2 8.3; do
     cp /mods-available/sqlsrv.ini "/etc/php/${PHP_VERSION}/mods-available/sqlsrv.ini"
 done

--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -7,10 +7,10 @@ cd tmp
 # Download extension versions from MS
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.1/Ubuntu2004-7.4.tar | tar xf - --strip-components=1 Ubuntu2004-7.4/php_pdo_sqlsrv_74_nts.so Ubuntu2004-7.4/php_sqlsrv_74_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.0/Ubuntu2004-8.0.tar | tar xf - --strip-components=1 Ubuntu2004-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2004-8.0/php_sqlsrv_80_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.0/Ubuntu2004-8.1.tar | tar xf - --strip-components=1 Ubuntu2004-8.1/php_pdo_sqlsrv_81_nts.so Ubuntu2004-8.1/php_sqlsrv_81_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.0/Ubuntu2004-8.2.tar | tar xf - --strip-components=1 Ubuntu2004-8.2/php_pdo_sqlsrv_82_nts.so Ubuntu2004-8.2/php_sqlsrv_82_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.12.0-beta1/Ubuntu2004-8.3.tar | tar xf - --strip-components=1 Ubuntu2004-8.3/php_pdo_sqlsrv_83_nts.so Ubuntu2004-8.3/php_sqlsrv_83_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.1/Ubuntu2204-8.0.tar | tar xf - --strip-components=1 Ubuntu2204-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2204-8.0/php_sqlsrv_80_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.1/Ubuntu2204-8.1.tar | tar xf - --strip-components=1 Ubuntu2204-8.1/php_pdo_sqlsrv_81_nts.so Ubuntu2204-8.1/php_sqlsrv_81_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.1/Ubuntu2204-8.2.tar | tar xf - --strip-components=1 Ubuntu2204-8.2/php_pdo_sqlsrv_82_nts.so Ubuntu2204-8.2/php_sqlsrv_82_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.12.0-beta1/Ubuntu2204-8.3.tar | tar xf - --strip-components=1 Ubuntu2204-8.3/php_pdo_sqlsrv_83_nts.so Ubuntu2204-8.3/php_sqlsrv_83_nts.so
 
 # Copy extensions to appropriate locations for each PHP version
 mv php_pdo_sqlsrv_73_nts.so "$(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

As this is a beta release, it should not be used for PHP 8.1 and 8.2.

- Fixes #204

https://github.com/microsoft/msphpsql/releases/tag/v5.12.0-beta1