### PR TITLE
Bump composer in container to 2.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Aliasing base images, so we can change just this, when needing to upgrade or pull base layers
 FROM ubuntu:22.04 AS base-distro
-FROM composer:2.4.4 AS composer
+FROM composer:2.6.6 AS composer
 
 
 FROM base-distro AS install-markdownlint


### PR DESCRIPTION
Renovate bundles this update with markdownlint in #133  that is potentially blocked for now.

Bump it independently here and markdownlint update can be investigated there.