### PR TITLE
Update PHP Driver for SQL Server to 5.12.0

### DIFF
--- a/mods-install/install_sqlsrv.sh
+++ b/mods-install/install_sqlsrv.sh
@@ -8,9 +8,9 @@ cd tmp
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.9.0/Ubuntu2004-7.3.tar | tar xf - --strip-components=1 Ubuntu2004-7.3/php_pdo_sqlsrv_73_nts.so Ubuntu2004-7.3/php_sqlsrv_73_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.10.1/Ubuntu2004-7.4.tar | tar xf - --strip-components=1 Ubuntu2004-7.4/php_pdo_sqlsrv_74_nts.so Ubuntu2004-7.4/php_sqlsrv_74_nts.so
 curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.1/Ubuntu2204-8.0.tar | tar xf - --strip-components=1 Ubuntu2204-8.0/php_pdo_sqlsrv_80_nts.so Ubuntu2204-8.0/php_sqlsrv_80_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.1/Ubuntu2204-8.1.tar | tar xf - --strip-components=1 Ubuntu2204-8.1/php_pdo_sqlsrv_81_nts.so Ubuntu2204-8.1/php_sqlsrv_81_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.11.1/Ubuntu2204-8.2.tar | tar xf - --strip-components=1 Ubuntu2204-8.2/php_pdo_sqlsrv_82_nts.so Ubuntu2204-8.2/php_sqlsrv_82_nts.so
-curl -L https://github.com/microsoft/msphpsql/releases/download/v5.12.0-beta1/Ubuntu2204-8.3.tar | tar xf - --strip-components=1 Ubuntu2204-8.3/php_pdo_sqlsrv_83_nts.so Ubuntu2204-8.3/php_sqlsrv_83_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.12.0/Ubuntu2204-8.1.tar | tar xf - --strip-components=1 Ubuntu2204-8.1/php_pdo_sqlsrv_81_nts.so Ubuntu2204-8.1/php_sqlsrv_81_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.12.0/Ubuntu2204-8.2.tar | tar xf - --strip-components=1 Ubuntu2204-8.2/php_pdo_sqlsrv_82_nts.so Ubuntu2204-8.2/php_sqlsrv_82_nts.so
+curl -L https://github.com/microsoft/msphpsql/releases/download/v5.12.0/Ubuntu2204-8.3.tar | tar xf - --strip-components=1 Ubuntu2204-8.3/php_pdo_sqlsrv_83_nts.so Ubuntu2204-8.3/php_sqlsrv_83_nts.so
 
 # Copy extensions to appropriate locations for each PHP version
 mv php_pdo_sqlsrv_73_nts.so "$(php7.3 -i | grep -P '^extension_dir' | sed -E -e 's/^extension_dir\s+=>\s+\S+\s+=>\s+(.*)$/\1/')/pdo_sqlsrv.so"


### PR DESCRIPTION
New release dropped support for 8.0. Supported php versions updated to install 5.12.0