### PR TITLE
Update markdownlint configuration for list indentation

### DIFF
--- a/setup/markdownlint/markdownlint.json
+++ b/setup/markdownlint/markdownlint.json
@@ -1,5 +1,6 @@
 {
     "default": true,
+    "MD007": { "indent": 4 },
     "MD013": false,
     "MD014": false,
     "MD024": false,


### PR DESCRIPTION
The configuration for markdownlint has been updated to include setting the indentation of list item to 4 spaces ("MD007"). This is intended to ensure the correct formatting for markdown documents in MkDocs.

References:

- https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md
- https://python-markdown.github.io/#differences