### PR TITLE
Migrate from PPA for PHP to https://packages.sury.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,9 @@ RUN set -eux; \
     && dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb \
     && mkdir -p /etc/apt/keyrings \
-    && add-apt-repository -y ppa:ondrej/php \
+    && curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb \
+    && dpkg -i /tmp/debsuryorg-archive-keyring.deb \
+    && sh -c 'echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list' \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "Types: deb\nURIs: https://deb.nodesource.com/node_${NODE_MAJOR}.x/\nSuites: nodistro\nComponents: main\nSigned-By: /etc/apt/keyrings/nodesource.gpg" | tee /etc/apt/sources.list.d/nodesource.sources \
     && apt update \


### PR DESCRIPTION
Currently unsure if the new repository contains all the packages that might be needed.

The alternative is to simply add `--allow-releaseinfo-change` to `apt update` - I'll send in a patch for that as an alternative.

For more context: https://codeberg.org/oerdnj/deb.sury.org/issues/73

And the reason for this patch is that any action run that needs custom extensions is failing because the `ppa:ondrej/php` has "Updated it's labels"