### PR TITLE
fix: a label change for the main PHP PPA for Ubuntu is causing extension installation failure

### DIFF
--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -73,7 +73,7 @@ function install_packaged_extensions {
     fi
 
     echo "Installing packaged extensions: ${TO_INSTALL}"
-    apt update
+    apt --allow-releaseinfo-change update
     # shellcheck disable=SC2086,SC2046
     apt install -y ${TO_INSTALL}
 }


### PR DESCRIPTION
Related to #383 

This could go out as a patch release maybe, and we could not merge #383 in case all pkgs are not yet avaialable in the new repo